### PR TITLE
feat: Added support for Cohere Embed and Titan Embeddings models

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from mangum import Mangum
 
-from api.routers import model, chat
+from api.routers import model, chat, embeddings
 from api.setting import API_ROUTE_PREFIX, TITLE, DESCRIPTION, SUMMARY, VERSION
 
 config = {
@@ -33,6 +33,7 @@ app.add_middleware(
 
 app.include_router(model.router, prefix=API_ROUTE_PREFIX)
 app.include_router(chat.router, prefix=API_ROUTE_PREFIX)
+app.include_router(embeddings.router, prefix=API_ROUTE_PREFIX)
 
 
 @app.get("/health")

--- a/src/api/models/__init__.py
+++ b/src/api/models/__init__.py
@@ -1,1 +1,7 @@
-from api.models.bedrock import ClaudeModel, SUPPORTED_BEDROCK_MODELS, get_model
+from api.models.bedrock import (
+	ClaudeModel,
+	SUPPORTED_BEDROCK_MODELS,
+	SUPPORTED_BEDROCK_EMBEDDING_MODELS,
+	get_model,
+	get_embeddings_model,
+)

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -483,8 +483,12 @@ def get_embeddings_model(model_id: str) -> BedrockEmbeddingsModel:
 class CohereEmbeddingsModel(BedrockEmbeddingsModel):
 
     def _parse_args(self, embeddings_request: EmbeddingsRequest) -> dict:
+        if isinstance(embeddings_request.input, str):
+            texts = [embeddings_request.input]
+        elif isinstance(embeddings_request.input, list):
+            texts = embeddings_request.input
         args = {
-            "texts": embeddings_request.input,
+            "texts": texts,
             "input_type": embeddings_request.input_type if embeddings_request.input_type else "search_document",
             "truncate": embeddings_request.truncate if embeddings_request.truncate else "NONE",
         }

--- a/src/api/routers/embeddings.py
+++ b/src/api/routers/embeddings.py
@@ -1,0 +1,43 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Body, HTTPException
+
+from api.auth import api_key_auth
+from api.models import get_embeddings_model, SUPPORTED_BEDROCK_EMBEDDING_MODELS
+from api.schema import EmbeddingsRequest, EmbeddingsResponse
+from api.setting import DEFAULT_EMBEDDING_MODEL
+
+router = APIRouter()
+
+router = APIRouter(
+    prefix="/embeddings",
+    tags=["items"],
+    dependencies=[Depends(api_key_auth)],
+)
+
+
+@router.post("/", response_model=EmbeddingsResponse)
+async def embeddings(
+        embeddings_request: Annotated[
+            EmbeddingsRequest,
+            Body(
+                examples=[
+                    {
+                        "model": "cohere.embed-multilingual-v3",
+                        "input": [
+                            "Your text string goes here"
+                        ],
+                    }
+                ],
+            ),
+        ]
+):
+    if embeddings_request.model.lower().startswith("text-embedding-"):
+        embeddings_request.model = DEFAULT_EMBEDDING_MODEL
+    if embeddings_request.model not in SUPPORTED_BEDROCK_EMBEDDING_MODELS.keys():
+        raise HTTPException(status_code=400, detail="Unsupported Model Id " + embeddings_request.model)
+    try:
+        model = get_embeddings_model(embeddings_request.model)
+        return model.embed(embeddings_request)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/src/api/routers/model.py
+++ b/src/api/routers/model.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Path
 
 from api.auth import api_key_auth
-from api.models import SUPPORTED_BEDROCK_MODELS
+from api.models import SUPPORTED_BEDROCK_MODELS, SUPPORTED_BEDROCK_EMBEDDING_MODELS
 from api.schema import Models, Model
 
 router = APIRouter()
@@ -17,13 +17,13 @@ router = APIRouter(
 
 
 async def validate_model_id(model_id: str):
-    if model_id not in SUPPORTED_BEDROCK_MODELS.keys():
+    if model_id not in (SUPPORTED_BEDROCK_MODELS | SUPPORTED_BEDROCK_EMBEDDING_MODELS).keys():
         raise HTTPException(status_code=400, detail="Unsupported Model Id")
 
 
 @router.get("/", response_model=Models)
 async def list_models():
-    model_list = [Model(id=model_id) for model_id in SUPPORTED_BEDROCK_MODELS.keys()]
+    model_list = [Model(id=model_id) for model_id in (SUPPORTED_BEDROCK_MODELS | SUPPORTED_BEDROCK_EMBEDDING_MODELS).keys()]
     return Models(data=model_list)
 
 

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -78,3 +78,36 @@ class ChatResponse(BaseChatResponse):
 class ChatStreamResponse(BaseChatResponse):
     choices: list[ChoiceDelta]
     object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+
+
+class EmbeddingsRequest(BaseModel):
+    input: str | list[str]
+    model: str
+    # Cohere Embed
+    input_type: Literal["search_document", "search_query", "classification", "clustering"] | None = None
+    truncate: Literal["NONE", "LEFT", "RIGHT"] | None = None
+    # Titan Embeddings
+    embedding_config: dict | None = None
+
+
+class BaseEmbeddingsResponse(BaseModel):
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    system_fingerprint: str = "fp_e97c09dd4e26"
+
+
+class Embedding(BaseModel):
+    object: Literal["embedding"] = "embedding"
+    embedding: list[float]
+    index: int
+
+
+class EmbeddingsUsage(BaseModel):
+    prompt_tokens: int
+    total_tokens: int
+
+
+class EmbeddingsResponse(BaseEmbeddingsResponse):
+    data: list[Embedding]
+    object: Literal["list"] = "list"
+    usage: EmbeddingsUsage

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -93,7 +93,6 @@ class EmbeddingsRequest(BaseModel):
 class BaseEmbeddingsResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
     model: str
-    system_fingerprint: str = "fp_e97c09dd4e26"
 
 
 class Embedding(BaseModel):

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -11,6 +11,8 @@ DESCRIPTION = """
 Use OpenAI-Compatible RESTful APIs for Amazon Bedrock models.
 
 List of Amazon Bedrock models currently supported:
+
+# Chat
 - anthropic.claude-instant-v1
 - anthropic.claude-v2:1
 - anthropic.claude-v2
@@ -20,8 +22,15 @@ List of Amazon Bedrock models currently supported:
 - meta.llama2-70b-chat-v1
 - mistral.mistral-7b-instruct-v0:2
 - mistral.mixtral-8x7b-instruct-v0:1
+
+# Embeddings
+- cohere.embed-multilingual-v3
+- cohere.embed-english-v3
+- amazon.titan-embed-text-v1
+- amazon.titan-embed-image-v1
 """
 
 DEBUG = os.environ.get("DEBUG", "false").lower() != "false"
 AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
 DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0")
+DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3")


### PR DESCRIPTION
This PR adds support for Bedrock-provided Embeddings models (text only) by implementing the [OpenAI's `embeddings` route](https://platform.openai.com/docs/api-reference/embeddings).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Example:**

```python
import os
from openai import OpenAI

client = OpenAI(
    base_url=os.environ['OPENAI_BASE_URL'],
    api_key=os.environ['OPENAI_API_KEY']
)

##### Models

models = client.models.list()

embedding_models = list(
    map(
        lambda model: model.id,
        filter(
            lambda model: "embed" in model.id,
            models.data
        )
))

print(embedding_models)

##### Embeddings

embeddings = client.embeddings.create(
    input = ["Olá mundo!", "Hello World!"],
    model="cohere.embed-multilingual-v3"
)

for item in embeddings.data:
    print(item.embedding[:10])

```

**Output:**

```zsh
['cohere.embed-multilingual-v3', 'cohere.embed-english-v3', 'amazon.titan-embed-text-v1', 'amazon.titan-embed-image-v1']
[0.0017204285, 0.04119873, 0.024536133, -0.01625061, 0.001581192, 0.010940552, -0.0211792, -0.050720215, -0.041534424, 0.0053710938]
[0.008758545, 0.050598145, 0.022613525, 0.0124435425, -0.024017334, -0.0057029724, -0.03451538, -0.043151855, -0.039520264, 0.034698486]
```