### PR TITLE
Fix for "Runtime.InvalidEntrypoint" error when deploying custom Lambda Image via Cloudformation

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.12-arm64
 
 COPY ./api ./api
 


### PR DESCRIPTION
*Issue #, if available:*
When you create a custom image and upload it via cloudformation, using `scripts/push-to-ecr.sh`, accessing the lambda function results in a `502 bad gateway` error. The Cloudwatch logs show the following error message:
{
  "errorType": "Runtime.InvalidEntrypoint",
  "errorMessage": "RequestId: xxx Error: fork/exec /lambda-entrypoint.sh: exec format error"
}

*Description of changes:*
The Dockerfile needs to contain the appropriate architecture tag for the runtime image:
`FROM public.ecr.aws/lambda/python:3.12-arm64`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
