### PR TITLE
feat: allow the use of an ENV variable to set the API key if the ParameterStore isn't used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Please follow the steps below to deploy the Bedrock Proxy APIs into your AWS acc
 
 **Step 1: Create your own custom API key (Optional)**
 
+#### Store API Key in ParameterStore
+
 > **Note:** This step is to use any string (without spaces) you like to create a custom API Key (credential) that will be used to access the proxy API later. This key does not have to match your actual OpenAI key, and you don't need to have an OpenAI API key. It is recommended that you take this step and ensure that you keep the key safe and private.
 
 1. Open the AWS Management Console and navigate to the Systems Manager service.
@@ -84,6 +86,10 @@ Please follow the steps below to deploy the Bedrock Proxy APIs into your AWS acc
     - Value: Any string (without spaces).
 5. Click "Create parameter".
 6. Make a note of the parameter name you used (e.g., "BedrockProxyAPIKey"). You'll need this in the next step.
+
+#### Store API Key in ENV variable
+
+1. Provide an ENV variable to the container named: `API_KEY` with the API key value.
 
 **Step 2: Deploy the CloudFormation stack**
 

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -3,16 +3,19 @@ from typing import Annotated
 
 import boto3
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from api.setting import DEFAULT_API_KEYS
 
 api_key_param = os.environ.get("API_KEY_PARAM_NAME")
+api_key_env = os.environ.get("API_KEY")
 if api_key_param:
     ssm = boto3.client("ssm")
     api_key = ssm.get_parameter(Name=api_key_param, WithDecryption=True)["Parameter"][
         "Value"
     ]
+elif api_key_env:
+    api_key = api_key_env
 else:
     api_key = DEFAULT_API_KEYS
 
@@ -20,7 +23,7 @@ security = HTTPBearer()
 
 
 def api_key_auth(
-    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)]
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
 ):
     if credentials.credentials != api_key:
         raise HTTPException(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We'd like to be able to set the API key using an environment variable instead of just parameter store. This PR sets the API_KEY env variable to be a lower priority than parameter store but still usable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
