### PR TITLE
Lately Claude models (specifically Opus and Sonnet 3.5) return throttle exceptions even if limits have not been exceeded; therefore I modified the lambda function so that if it encounters such an error, it will cycle through 4 different models (defined as environment variables) so as to generate an answer even if it is with a different model.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 .idea/
 
 Config
+tests/request.http

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -20,9 +20,13 @@ List of Amazon Bedrock models currently supported:
 
 DEBUG = os.environ.get("DEBUG", "false").lower() != "false"
 AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
-DEFAULT_MODEL = os.environ.get(
-    "DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0"
-)
+CURRENT_MODEL = [
+    os.environ.get("DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0"),
+    os.environ.get("MODEL_2", "anthropic.claude-3-5-sonnet-20240620-v1:0"),
+    os.environ.get("MODEL_3", "meta.llama3-1-405b-instruct-v1:0"),
+    os.environ.get("MODEL_4", "anthropic.claude-3-sonnet-20240229-v1:0")
+]
+CURRENT_MODEL_INDEX = 0
 DEFAULT_EMBEDDING_MODEL = os.environ.get(
     "DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3"
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
