### PR TITLE
Add environment variable for PORT

### DIFF
--- a/src/Dockerfile_ecs
+++ b/src/Dockerfile_ecs
@@ -8,4 +8,6 @@ RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 COPY ./api /app/api
 
-CMD ["uvicorn", "api.app:app", "--host", "0.0.0.0", "--port", "80"]
+ENV PORT 80
+
+CMD ["uvicorn", "api.app:app", "--host", "0.0.0.0", "--port", "${PORT}"]

--- a/src/Dockerfile_ecs
+++ b/src/Dockerfile_ecs
@@ -10,4 +10,4 @@ COPY ./api /app/api
 
 ENV PORT 80
 
-CMD ["uvicorn", "api.app:app", "--host", "0.0.0.0", "--port", "${PORT}"]
+CMD ["sh", "-c", "uvicorn api.app:app --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
*Issue #, if available:* 46

*Description of changes:* An environment variable `PORT` was added with the default value of 80 to maintain compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
