### PR TITLE
Added "new Claude 3.5 Sonnet" v2 model to the list

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -107,6 +107,12 @@ class BedrockModel(BaseChatModel):
             "tool_call": True,
             "stream_tool_call": True,
         },
+        "anthropic.claude-3-5-sonnet-20241022-v2:0": {
+            "system": True,
+            "multimodal": True,
+            "tool_call": True,
+            "stream_tool_call": True,
+        },
         "meta.llama2-13b-chat-v1": {
             "system": True,
             "multimodal": False,


### PR DESCRIPTION
Added newly introduced model "new Claude 3.5 Sonnet" (anthropic.claude-3-5-sonnet-20241022-v2:0)
to the hardcoded list of models