### PR TITLE
feat: add amazon nova inference profiles in us

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -312,6 +312,25 @@ class BedrockModel(BaseChatModel):
             "tool_call": True,
             "stream_tool_call": True,
         },
+        # Amazon Nova models - AWS's proprietary large language models
+        "us.amazon.nova-lite-v1:0": {
+            "system": True,      # Supports system prompts for context setting
+            "multimodal": True,  # Capable of processing both text and images
+            "tool_call": True,
+            "stream_tool_call": True,
+        },
+        "us.amazon.nova-micro-v1:0": {
+            "system": True,      # Supports system prompts for context setting
+            "multimodal": False, # Text-only model, no image processing capabilities
+            "tool_call": True,
+            "stream_tool_call": True,
+        },
+        "us.amazon.nova-pro-v1:0": {
+            "system": True,      # Supports system prompts for context setting
+            "multimodal": True,  # Capable of processing both text and images
+            "tool_call": True,
+            "stream_tool_call": True,
+        },
     }
 
     def list_models(self) -> list[str]:


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Added support for new Amazon Nova models in Bedrock:
- us.amazon.nova-pro-v1:0: Advanced multimodal model supporting text and vision
- us.amazon.nova-lite-v1:0: Balanced multimodal model supporting text and vision  
- us.amazon.nova-micro-v1:0: Lightweight text-only model

Changes include:
- Added model configurations to _supported_models dictionary
- Set multimodal capability for Pro and Lite models (True)
- Set multimodal capability for Micro model (False)
- Added descriptive comments for future maintainability

Note: Tool calling capabilities need to be confirmed with official AWS documentation and updated accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.