### PR TITLE
Automatic Publishing of Docker Images To Git Registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,34 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build the Docker image
+        run: |
+          cd src/
+          docker build . --file Dockerfile --tag ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ github.sha }}
+
+      - name: Push the Docker image to GitHub Container Registry
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ github.sha }}
+
+      - name: Build the Docker_ecs image
+        run: |
+          cd src/
+          docker build . --file Dockerfile_ecs --tag ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ github.sha }}-ecs
+
+      - name: Push the Docker_ecs image to GitHub Container Registry
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ github.sha }}-ecs

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,24 +11,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+      
+      - name: Set short commit SHA
+        id: vars
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+        
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build the Docker image
         run: |
           cd src/
-          docker build . --file Dockerfile --tag ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ github.sha }}
+          docker build . --file Dockerfile \
+            --tag ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ env.SHORT_SHA }} \
+            --tag ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:latest \
+            
 
       - name: Push the Docker image to GitHub Container Registry
         run: |
-          docker push ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ env.SHORT_SHA }}
+          docker push ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:latest
 
       - name: Build the Docker_ecs image
         run: |
           cd src/
-          docker build . --file Dockerfile_ecs --tag ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ github.sha }}-ecs
+          docker build . --file Dockerfile_ecs \
+            --tag ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ env.SHORT_SHA }}-ecs \
+            --tag ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:latest-ecs \
 
       - name: Push the Docker_ecs image to GitHub Container Registry
         run: |
-          docker push ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ github.sha }}-ecs
+          docker push ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:${{ env.SHORT_SHA }}-ecs
+          docker push ghcr.io/${{ github.repository_owner }}/bedrock-access-gateway:latest-ecs


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Adding a github workflow that builds and uploads the gateway and gateway-ecs images on merges to main to the github container registry.

*Important call-outs to this PR:*
- since this repo does not appear to currently be using any versioning I configured to trigger on pushes/merges to main. For the same reason, i am tagging the images with the first several letters of their commit hash so they can be easily tracked to a point in time. (referred to as `SHORT_SHA`)
- we build two images on each merge to main: `SHORT_SHA` and `SHORT_SHA-ecs`
- can certainly be done with aws ecr but i figured this would be the shortest path to getting published container images as we will inherit github organization permissions to access the registry for upload vs managing aws credentials or docker credentials for ECR/DockerHub respectively. 

*Other:*
if this is already published somewhere please add to docs! I luckily only took a short side step here to make this happen since i had a lot of the workflow file sitting around from other projects and know the eco system well but i am sure this could create a lot of friction/ poor DX for those not as familiar. 

All in all though thanks for the work here in building this, seems to be a rock solid implementation and hope that the more i use it, the more I can contribute! Cheers to you guys for this. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
