### PR TITLE
Add Titan Embeddings G2

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -69,7 +69,7 @@ SUPPORTED_BEDROCK_EMBEDDING_MODELS = {
     "cohere.embed-multilingual-v3": "Cohere Embed Multilingual",
     "cohere.embed-english-v3": "Cohere Embed English",
     # Disable Titan embedding.
-    # "amazon.titan-embed-text-v1": "Titan Embeddings G1 - Text",
+    "amazon.titan-embed-text-v2:0": "Titan Embeddings G2 - Text",
     # "amazon.titan-embed-image-v1": "Titan Multimodal Embeddings G1"
 }
 
@@ -852,6 +852,8 @@ def get_embeddings_model(model_id: str) -> BedrockEmbeddingsModel:
     match model_name:
         case "Cohere Embed Multilingual" | "Cohere Embed English":
             return CohereEmbeddingsModel()
+        case "Titan Embeddings G2 - Text":
+            return TitanEmbeddingsModel()
         case _:
             logger.error("Unsupported model id " + model_id)
             raise HTTPException(


### PR DESCRIPTION
The bedrock access gateway does not allow the usage of Titan Embeddings GS2, although they are not available on a lot of regions in aws.

This change will allow the usage of this model