### PR TITLE
feat: Enable Imported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,12 @@ Replace the repo url in the CloudFormation template before you deploy.
 Yes, you can run this locally, e.g. run below command under `src` folder:
 
 ```bash
+cd src/
+pip install -r requirements.txt
 uvicorn api.app:app --host 0.0.0.0 --port 8000
 ```
 
-The API base url should look like `http://localhost:8000/api/v1`.
+The API base url should look like `http://localhost:8000/api/v1` and the API key should be `bedrock`.
 
 ### Any performance sacrifice or latency increase by using the proxy APIs
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,10 @@ Please follow the steps below to deploy the Bedrock Proxy APIs into your AWS acc
 
 1. Sign in to AWS Management Console, switch to the region to deploy the CloudFormation Stack to.
 2. Click the following button to launch the CloudFormation Stack in that region. Choose one of the following:
-   - **ALB + Lambda**
 
-      [![Launch Stack](assets/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/template?stackName=BedrockProxyAPI&templateURL=https://aws-gcr-solutions.s3.amazonaws.com/bedrock-access-gateway/latest/BedrockProxy.template)
-   - **ALB + Fargate**
+      [<kbd> <br> ALB + Lambda 1-Click Deploy 🚀 <br> </kbd>](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://aws-gcr-solutions.s3.amazonaws.com/bedrock-access-gateway/latest/BedrockProxy.template&stackName=BedrockProxyAPI)
 
-      [![Launch Stack](assets/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/template?stackName=BedrockProxyAPI&templateURL=https://aws-gcr-solutions.s3.amazonaws.com/bedrock-access-gateway/latest/BedrockProxyFargate.template)
+      [<kbd> <br> ALB + Fargate 1-Click Deploy 🚀 <br> </kbd>](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://aws-gcr-solutions.s3.amazonaws.com/bedrock-access-gateway/latest/BedrockProxyFargate.template&stackName=BedrockProxyAPI)
 3. Click "Next".
 4. On the "Specify stack details" page, provide the following information:
     - Stack name: Change the stack name if needed.
@@ -116,6 +114,10 @@ Please follow the steps below to deploy the Bedrock Proxy APIs into your AWS acc
 8. Click "Create stack".
 
 That is it! 🎉 Once deployed, click the CloudFormation stack and go to **Outputs** tab, you can find the API Base URL from `APIBaseUrl`, the value should look like `http://xxxx.xxx.elb.amazonaws.com/api/v1`.
+
+### Troubleshooting
+
+If you encounter any issues, please check the [Troubleshooting Guide](./docs/Troubleshooting.md) for more details.
 
 ### SDK/API Usage
 

--- a/deployment/BedrockProxy.yaml
+++ b/deployment/BedrockProxy.yaml
@@ -5,6 +5,13 @@ Parameters:
     Type: String
     Default: ""
     Description: The parameter name in System Manager used to store the API Key, leave blank to use a default key
+  EnableImportedModels:
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    Description: If enabled, models imported into Bedrock will be available to use.
 Resources:
   VPCB9E5F0B4:
     Type: AWS::EC2::VPC
@@ -197,6 +204,7 @@ Resources:
               - DefaultValue: anthropic.claude-3-sonnet-20240229-v1:0
           DEFAULT_EMBEDDING_MODEL: cohere.embed-multilingual-v3
           ENABLE_CROSS_REGION_INFERENCE: "true"
+          ENABLE_IMPORTED_MODELS: !Ref EnableImportedModels
       MemorySize: 1024
       PackageType: Image
       Role:

--- a/deployment/BedrockProxyFargate.yaml
+++ b/deployment/BedrockProxyFargate.yaml
@@ -5,6 +5,13 @@ Parameters:
     Type: String
     Default: ""
     Description: The parameter name in System Manager used to store the API Key, leave blank to use a default key
+  EnableImportedModels:
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    Description: If enabled, models imported into Bedrock will be available to use.
 Resources:
   VPCB9E5F0B4:
     Type: AWS::EC2::VPC
@@ -237,6 +244,8 @@ Resources:
               Value: cohere.embed-multilingual-v3
             - Name: ENABLE_CROSS_REGION_INFERENCE
               Value: "true"
+            - Name: ENABLE_IMPORTED_MODELS
+              Value: !Ref EnableImportedModels
           Essential: true
           Image:
             Fn::Join:

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,0 +1,97 @@
+# Troubleshooting Guide
+
+This guide helps you troubleshoot common issues you might encounter when using the Bedrock Access Gateway.
+
+## Common Issues
+
+### 1. Parameter Store Access Error
+
+To see errors, first you need to access the CloudWatch Logs of the Lambda/Fargate instance.
+
+1. Go to the [CloudWatch Console](https://console.aws.amazon.com/cloudwatch/home?#logsV2:log-groups/)
+2. Search for `/aws/lambda/BedrockProxyAPI`
+3. Click on the `Log Stream` to see the error details
+
+```python
+botocore.exceptions.ClientError: An error occurred (ParameterNotFound) when calling the GetParameter operation: Parameter /BedrockProxyAPIKey not found.
+```
+
+This error occurs when the Lambda function cannot access the API key parameter in Parameter Store.
+
+**Possible solutions:**
+- Verify that you created the parameter in Parameter Store with the correct name
+- Check that the parameter name in the CloudFormation stack matches the one in Parameter Store
+- Ensure the Lambda function's IAM role has permission to access Parameter Store
+- If you didn't set up an API key, leave the `ApiKeyParam` field blank during deployment
+
+### 2. Model Access Issues
+
+If you receive an error about model access:
+
+```
+{"error": {"message": "User: arn:aws:iam::XXXX:role/XXX is not authorized to perform: bedrock:InvokeModel on resource: arn:aws:bedrock:REGION::foundation-model/XXX", "type": "auth_error", "code": 401}}
+```
+
+**Possible solutions:**
+- Ensure you have requested access to the model in Amazon Bedrock
+- Verify the Lambda/Fargate role has the necessary permissions to invoke Bedrock models
+- Check that you're using the correct model ID
+- Verify the model is available in your chosen region
+
+### 3. API Key Authentication Failures
+
+If you receive a 401 Unauthorized error:
+
+```
+{"detail": "Could not validate credentials"}
+```
+
+**Possible solutions:**
+- Verify you're using the correct API key in your requests
+- Check that the `Authorization` header is properly formatted (`Bearer YOUR-API-KEY`)
+- If using environment variables, ensure `OPENAI_API_KEY` is set correctly
+
+### 4. Cross-Region Access Issues
+
+If you're trying to access models in a different region:
+
+```
+{"error": {"message": "Region 'us-east-1' is not enabled for your account", "type": "invalid_request_error", "code": 400}}
+```
+
+**Possible solutions:**
+- Ensure the target region is enabled for your AWS account
+- Verify the model you're trying to access is available in that region
+- Check that your IAM roles have the necessary cross-region permissions
+
+### 5. Rate Limiting and Quotas
+
+If you're experiencing throttling or quota issues:
+
+```
+{"error": {"message": "Rate limit exceeded", "type": "rate_limit_error", "code": 429}}
+```
+
+**Possible solutions:**
+- Check your Bedrock service quotas in the AWS Console
+- Consider implementing retry logic in your application
+- Request a quota increase if needed
+
+## Getting Help
+
+If you're still experiencing issues:
+
+1. Check the CloudWatch Logs for detailed error messages
+2. Verify your AWS credentials and permissions
+3. Review the [Usage Guide](./Usage.md) for correct API usage
+4. Open a [GitHub issue](https://github.com/aws-samples/bedrock-access-gateway/issues/new?template=bug_report.md) with:
+   - Detailed error message
+   - Steps to reproduce
+   - Your deployment configuration (region, model, etc.)
+   - Any relevant CloudWatch logs
+
+## Additional Resources
+
+- [Amazon Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+- [AWS IAM Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/)
+- [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html)

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -38,7 +38,7 @@ from api.schema import (
     Embedding,
 
 )
-from api.setting import DEBUG, AWS_REGION, ENABLE_CROSS_REGION_INFERENCE, DEFAULT_MODEL
+from api.setting import DEBUG, AWS_REGION, ENABLE_CROSS_REGION_INFERENCE, DEFAULT_MODEL, ENABLE_IMPORTED_MODELS
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +98,17 @@ def list_bedrock_models() -> dict:
         response = bedrock_client.list_foundation_models(
             byOutputModality='TEXT'
         )
+
+        # Add imported models to the list if ENABLE_IMPORTED_MODELS is true
+        if ENABLE_IMPORTED_MODELS:
+            response_imported = bedrock_client.list_imported_models()
+
+            # Add imported models to the default model list
+            for model in response_imported['modelSummaries']:
+                model_id = model.get('modelArn')
+                model_list[model_id] = {
+                    'modalities': ["TEXT"]
+                }
 
         for model in response['modelSummaries']:
             model_id = model.get('modelId', 'N/A')

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -20,3 +20,4 @@ DEFAULT_EMBEDDING_MODEL = os.environ.get(
     "DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3"
 )
 ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
+ENABLE_IMPORTED_MODELS = os.environ.get("ENABLE_IMPORTED_MODELS", "true").lower() != "false"


### PR DESCRIPTION
This allows users to call models they've imported (if enabled by an environment variable):

For example:
```python
from openai import OpenAI

client = OpenAI()
completion = client.chat.completions.create(
    model="arn:aws:bedrock:us-west-2:<account-id>:imported-model/<model-id>",
    # model="meta.llama3-3-70b-instruct-v1:0",
    messages=[
        {
            "role": "user",
            "content": "Hello! please tell me a joke"
        }
    ],
)
```

These models also show up in the model list:

```python
client.models.list()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
