### PR TITLE
Fix issue with toolResult error with Cursor. 

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -291,23 +291,24 @@ class BedrockModel(BaseChatModel):
                             ),
                         }
                     )
-                else:
+                if message.tool_calls:
                     # Tool use message
-                    tool_input = json.loads(message.tool_calls[0].function.arguments)
-                    messages.append(
-                        {
-                            "role": message.role,
-                            "content": [
-                                {
-                                    "toolUse": {
-                                        "toolUseId": message.tool_calls[0].id,
-                                        "name": message.tool_calls[0].function.name,
-                                        "input": tool_input
+                    for tool_call in message.tool_calls:
+                        tool_input = json.loads(tool_call.function.arguments)
+                        messages.append(
+                            {
+                                "role": message.role,
+                                "content": [
+                                    {
+                                        "toolUse": {
+                                            "toolUseId": tool_call.id,
+                                            "name": tool_call.function.name,
+                                            "input": tool_input
+                                        }
                                     }
-                                }
-                            ],
-                        }
-                    )
+                                ],
+                            }
+                        )
             elif isinstance(message, ToolMessage):
                 # Bedrock does not support tool role,
                 # Add toolResult to content

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -1,6 +1,6 @@
 import time
 from typing import Literal, Iterable
-
+from api.setting import DEFAULT_MODEL
 from pydantic import BaseModel, Field
 
 
@@ -85,7 +85,7 @@ class StreamOptions(BaseModel):
 
 class ChatRequest(BaseModel):
     messages: list[SystemMessage | UserMessage | AssistantMessage | ToolMessage]
-    model: str
+    model: str = DEFAULT_MODEL
     frequency_penalty: float | None = Field(default=0.0, le=2.0, ge=-2.0)  # Not used
     presence_penalty: float | None = Field(default=0.0, le=2.0, ge=-2.0)  # Not used
     stream: bool | None = False

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -2,7 +2,7 @@ import os
 
 DEFAULT_API_KEYS = "bedrock"
 
-API_ROUTE_PREFIX = "/api/v1"
+API_ROUTE_PREFIX = os.environ.get("API_ROUTE_PREFIX", "/api/v1")
 
 TITLE = "Amazon Bedrock Proxy APIs"
 SUMMARY = "OpenAI-Compatible RESTful APIs for Amazon Bedrock"


### PR DESCRIPTION
Fix the issue with the toolResult error with the Cursor AI. 
Use default DEFAULT_MODEL in ChatRequest

*Issue #, if available:*
Resolve  issues: #109, #95, #84

*Description of changes:*
- This change resolves the unmatch tools bug when using cursor ai (See issues)
- Set a default model in the ChatRequest which allow cursor api
- Allow to set API_ROUTE_PREFIX from environment name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
