### PR TITLE
feat: implement boto3 connection pooling

### DIFF
--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -2,11 +2,11 @@ import json
 import os
 from typing import Annotated
 
-import boto3
 from botocore.exceptions import ClientError
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+from api.models.bedrock import client_manager
 from api.setting import DEFAULT_API_KEYS
 
 api_key_param = os.environ.get("API_KEY_PARAM_NAME")
@@ -15,10 +15,10 @@ api_key_env = os.environ.get("API_KEY")
 if api_key_param:
     # For backward compatibility.
     # Please now use secrets manager instead.
-    ssm = boto3.client("ssm")
+    ssm = client_manager.get_client("ssm")
     api_key = ssm.get_parameter(Name=api_key_param, WithDecryption=True)["Parameter"]["Value"]
 elif api_key_secret_arn:
-    sm = boto3.client("secretsmanager")
+    sm = client_manager.get_client("secretsmanager")
     try:
         response = sm.get_secret_value(SecretId=api_key_secret_arn)
         if "SecretString" in response:


### PR DESCRIPTION
- Add BedrockClientManager class to manage boto3 clients with connection pooling
- Improve connection reuse with max_pool_connections and tcp_keepalive
- Implement more resilient retry strategy
- Reuse clients across different AWS services (bedrock, ssm, secretsmanager)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
