### PR TITLE
Support for Custom Imported Models with User-Friendly IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+- Install dependencies: `cd src && uv pip install -r requirements.txt`
+- Run Python scripts: `cd src && uv run <script_name>.py`
+- Run locally: `cd src && uv run -m uvicorn api.app:app --host 0.0.0.0 --port 8000`
+- Build Docker: `cd scripts && bash ./push-to-ecr.sh`
+- Lint: `pipx run ruff check`
+- Format: `pipx run ruff format`
+
+## Environment Configuration
+- We use `uv` instead of regular `python` or `pip` commands
+- Enable debug mode: `export DEBUG=true`
+- Set AWS region: `export AWS_REGION=us-east-1`
+- Custom models are enabled by default
+
+## Code Style
+- Python version: 3.12
+- Line length: 120 characters max
+- Indentation: 4 spaces
+- Quote style: Double quotes for strings
+- Imports: Group (standard lib, third-party, internal) and alphabetically sorted
+- Use FastAPI patterns for API development
+- Type annotations required for all functions and classes
+- Use abstract base classes (ABC) for interfaces
+- Snake case for variables/functions, PascalCase for classes
+- Explicit error handling with specific exception types
+- Use HTTPException for API errors
+- Document public functions with docstrings
+
+## Architecture
+This project provides OpenAI-compatible RESTful APIs for Amazon Bedrock models, making it easy to use AWS foundation models without changing existing code that uses OpenAI APIs.
+
+## Testing
+- Test API functionality: `cd src && uv run test_api.py`
+- Test custom models: `cd src && uv run test_custom_models.py`

--- a/CUSTOM_MODELS_IMPLEMENTATION.md
+++ b/CUSTOM_MODELS_IMPLEMENTATION.md
@@ -1,0 +1,123 @@
+# Custom Imported Models Implementation
+
+## Overview
+
+This document describes the implementation of custom imported model support in the Bedrock Access Gateway. Custom models are models that you have imported into Bedrock, and this feature allows you to use them through the OpenAI-compatible API interface just like foundation models.
+
+## User-Friendly Model IDs
+
+One of the key features of this implementation is the creation of user-friendly model IDs that include the model name. Instead of cryptic AWS IDs like `custom.a1b2c3d4`, models are presented with descriptive IDs in the format:
+
+```
+{model-name}-id:custom.{aws_id}
+```
+
+For example: `mistral-7b-instruct-id:custom.a1b2c3d4`
+
+This makes it easier to identify models when using the Models API, while maintaining compatibility with the original AWS ID format.
+
+## Changes Made
+
+1. **Model Discovery**
+   - Extended `list_bedrock_models()` to include:
+     - Custom models via `bedrock_client.list_custom_models()`
+     - Imported models via `bedrock_client.list_imported_models()`
+   - Created user-friendly model IDs that include the model name
+   - Added type field to model metadata to distinguish between "foundation" and "custom" models
+   - Added region information to each model to support cross-region invocation
+   - Stored model ARN for custom models for invocation purposes
+
+2. **Configuration**
+   - Custom models are always enabled by default
+   - Added retry configuration for custom model invocation
+   - The implementation uses the local AWS region by default
+
+3. **Model Validation**
+   - Added ID transformation logic in the `validate()` method to handle both:
+     - Descriptive model IDs (e.g., `mistral-7b-instruct-id:custom.a1b2c3d4`)
+     - Original AWS IDs (e.g., `custom.a1b2c3d4`)
+   - Stores the original display ID to preserve it in responses
+
+4. **Model Invocation**
+   - Added branching logic in `_invoke_bedrock()` to handle custom models differently
+   - Implemented `_invoke_custom_model()` method to handle custom model invocation via `InvokeModel`/`InvokeModelWithResponseStream`
+   - Added custom model response parsing to handle various model output formats
+   - Implemented special handling for `ModelNotReadyException`
+   - Added region-specific client creation for cross-region models
+
+5. **Streaming Support**
+   - Added `_handle_custom_model_stream()` method to handle streaming responses
+   - Added support for parsing different streaming formats from custom models
+
+6. **Message Formatting**
+   - Implemented `_create_prompt_from_messages()` to convert OpenAI-style chat messages to text format for custom models
+
+7. **Documentation**
+   - Updated README.md to include new feature
+   - Updated Usage.md with custom model usage examples
+   - Updated FAQs to indicate custom model support
+
+## Usage
+
+### Listing Custom Models
+
+To list available custom models in your AWS account, use the Models API:
+
+```bash
+curl -s $OPENAI_BASE_URL/models -H "Authorization: Bearer $OPENAI_API_KEY" | jq '.data[] | select(.id | startswith("custom.") or contains("-id:custom."))'
+```
+
+### Using Custom Models
+
+Custom models can be used with either their descriptive ID or the original AWS ID:
+
+```bash
+# Using descriptive ID
+curl $OPENAI_BASE_URL/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d '{
+    "model": "mistral-7b-instruct-id:custom.a1b2c3d4",
+    "messages": [
+      { "role": "user", "content": "Hello, world!" }
+    ]
+  }'
+
+# Using original AWS ID (also supported)
+curl $OPENAI_BASE_URL/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d '{
+    "model": "custom.a1b2c3d4",
+    "messages": [
+      { "role": "user", "content": "Hello, world!" }
+    ]
+  }'
+```
+
+## Troubleshooting
+
+### Model Not Found
+
+If your custom model isn't appearing:
+
+1. Check if the model exists in your AWS account:
+   ```bash
+   aws bedrock list-imported-models --region us-east-1
+   ```
+
+2. Restart the gateway to refresh the model list:
+   ```bash
+   # For Lambda deployments
+   # Go to Lambda console > Find your function > Click "Deploy new image"
+   
+   # For Fargate deployments
+   # Go to ECS console > Find your cluster > Tasks tab > Stop running task
+   ```
+
+### Invocation Errors
+
+Common errors when invoking custom models:
+
+- `ModelNotReadyException`: The model is still being prepared - wait a few minutes and try again
+- `ValidationException`: Check that your input format is compatible with the model

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ If you find this GitHub repository useful, please consider giving it a free star
 - [x] Support Embedding API
 - [x] Support Multimodal API
 - [x] Support Cross-Region Inference
-- [x] Support Reasoning (**new**)
+- [x] Support Reasoning
+- [x] Support Custom Imported Models (**new**)
 
 Please check [Usage Guide](./docs/Usage.md) for more details about how to use the new APIs.
 
@@ -230,9 +231,13 @@ Also, you can use Lambda Web Adapter + Function URL (see [example](https://githu
 
 Currently, there is no plan to support SageMaker models. This may change provided there's a demand from customers.
 
-### Any plan to support Bedrock custom models?
+### Support for Bedrock custom models
 
-Fine-tuned models and models with Provisioned Throughput are currently not supported. You can clone the repo and make the customization if needed.
+Custom imported models are now supported! You can use them just like foundation models using user-friendly model IDs in the format `{model-name}-id:custom.{aws_id}` or with the original AWS format `custom.{aws_id}`. Run the Models API to see the available custom models in your account.
+
+The user-friendly format makes it easier to identify models while maintaining backward compatibility with the original AWS IDs. For more details, see [Custom Imported Models](./docs/Usage.md#custom-imported-models) in the usage documentation.
+
+Fine-tuned models and models with Provisioned Throughput may require additional configuration.
 
 ### How to upgrade?
 

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -102,6 +102,7 @@ class ChatRequest(BaseModel):
     tools: list[Tool] | None = None
     tool_choice: str | object = "auto"
     stop: list[str] | str | None = None
+    custom_model_display_name: str | None = None  # For storing the friendly model name when using custom models
 
 
 class Usage(BaseModel):

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -16,3 +16,5 @@ AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
 DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0")
 DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3")
 ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
+# Custom models are always enabled by default
+ENABLE_CUSTOM_MODELS = True


### PR DESCRIPTION
## Summary
- Add support for custom models imported into AWS Bedrock
- Create user-friendly model IDs that include the model name (e.g., `mistral-7b-instruct-id:custom.a1b2c3d4`)
- Maintain backward compatibility with original AWS IDs
- Preserve the user-friendly IDs in API responses

## Key Features
- Custom models are always enabled by default
- Models are discovered automatically from the AWS account
- User-friendly IDs are created based on model names
- Complete documentation in CUSTOM_MODELS_IMPLEMENTATION.md 
- Support for both streaming and non-streaming requests
- Support for model invocation across regions

## Test plan
1. Run the Models API to verify custom models appear with user-friendly IDs
2. Test chat completions with both ID formats (user-friendly and original AWS format)
3. Test streaming with custom models
4. Verify that responses preserve the user-friendly IDs

🤖 Generated with [Claude Code](https://claude.ai/code)