### PR TITLE
Enable DEFAULT_API_KEYS via Docker Environment Variable

### DIFF
--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -1,6 +1,6 @@
 import os
 
-DEFAULT_API_KEYS = "bedrock"
+DEFAULT_API_KEYS = os.environ.get("DEFAULT_API_KEYS", "bedrock")
 
 API_ROUTE_PREFIX = os.environ.get("API_ROUTE_PREFIX", "/api/v1")
 


### PR DESCRIPTION
_Issue #, if available:_  
Issue [137](https://github.com/aws-samples/bedrock-access-gateway/issues/137): Pass DEFAULT_API_KEYS via Docker env

_Description of changes:_  
- Modified `api/settings.py` to read `DEFAULT_API_KEYS` from the environment variable.
- Allows users to set `DEFAULT_API_KEYS` dynamically through Docker, providing enhanced flexibility for authentication configuration.

_Example Docker command to run with custom API key:_

```bash
docker run -d --name bedrock-gateway \
  -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
  -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
  -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
  -e AWS_REGION=us-east-1 \
  -e DEFAULT_API_KEYS=your_custom_api_key \
  -p 8000:80 \
  bedrock-gateway
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
