### PR TITLE
add titan G1 embeddings

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -68,8 +68,9 @@ cr_inference_prefix = get_inference_region_prefix()
 SUPPORTED_BEDROCK_EMBEDDING_MODELS = {
     "cohere.embed-multilingual-v3": "Cohere Embed Multilingual",
     "cohere.embed-english-v3": "Cohere Embed English",
-    # Disable Titan embedding.
+    "amazon.titan-embed-text-v1": "Titan Embeddings G1 - Text",
     "amazon.titan-embed-text-v2:0": "Titan Embeddings G2 - Text",
+    # Disable Titan embedding.
     # "amazon.titan-embed-image-v1": "Titan Multimodal Embeddings G1"
 }
 


### PR DESCRIPTION
In order to easily swap out models we need access to the only Bedrock embedding model that offers a vector of `1536` dimensions: `amazon.titan-embed-text-v1`

This pull request re-enables the model.

I saw that the Titan v2.0 embeddings are now supported, so I figure that the concern raised by #9  has since been resolved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
