### PR TITLE
support list application inference profile

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -92,6 +92,13 @@ def list_bedrock_models() -> dict:
             response = bedrock_client.list_inference_profiles(maxResults=1000, typeEquals="SYSTEM_DEFINED")
             profile_list = [p["inferenceProfileId"] for p in response["inferenceProfileSummaries"]]
 
+        # List application inference profile ARN defined by user, such as MAP tagged
+        app_profile_dict = {}
+        response = bedrock_client.list_inference_profiles(maxResults=1000, typeEquals="APPLICATION")
+        for p in response["inferenceProfileSummaries"]:
+            model = p['models'][0]['modelArn'].split('/')[1]
+            app_profile_dict[model] = p["inferenceProfileArn"]
+        
         # List foundation models, only cares about text outputs here.
         response = bedrock_client.list_foundation_models(byOutputModality="TEXT")
 
@@ -115,6 +122,10 @@ def list_bedrock_models() -> dict:
             if profile_id in profile_list:
                 model_list[profile_id] = {"modalities": input_modalities}
 
+            # Add Appilication inference profile list
+            if model_id in app_profile_dict:
+                model_list[app_profile_dict[model_id]] = {"modalities": input_modalities}
+    
     except Exception as e:
         logger.error(f"Unable to list models: {str(e)}")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*   support for application inference profiles created by users 

such as users who applied for Bedrock MAP,  they need to [create Application Inference Profiles with MAP tag based on foundation models or system Inference Profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-create.html), as docs  https://github.com/aws-samples/sample-bedrock-inference-profile-mgmt-tool 

after tagged, list Application Inference Profiles ARN in bedrock access gateway
```
'anthropic.claude-3-5-sonnet-20240620-v1:0': 'arn:aws:bedrock:us-west-2:808577411626:application-inference-profile/v8gtbe8pryd4'
'arn:aws:bedrock:us-west-2:808577411626:application-inference-profile/v8gtbe8pryd4': {'modalities': ['TEXT', 'IMAGE']},
```

users need to invoke model with Application Inference Profiles ARN
```
curl http://127.0.0.1:8000/api/v1/chat/completions \
-H "Content-Type: application/json" \
-H "Authorization: Bearer bedrock" \
-d '{
"model": "arn:aws:bedrock:us-west-2:xxxxxx:application-inference-profile/v8gtbe8pryd4",
"max_tokens": 4096,
"messages": [{
"role": "user",
"content": "the price of iphone16"
}]
}'
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
