### PR TITLE
models: fix Application Inference Profiles mapping

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -135,14 +135,6 @@ def list_bedrock_models() -> dict:
                         logger.warning(f"Error processing application profile: {e}")
                         continue
                     
-                    # Process all models in the profile
-                    models = profile.get("models", [])
-                    for model in models:
-                        model_arn = model.get("modelArn", "")
-                        if model_arn:
-                            model_id = model_arn.split('/')[-1] if '/' in model_arn else model_arn
-                            if model_id:
-                                app_profiles_by_model[model_id].add(profile_arn)
         # List foundation models, only cares about text outputs here.
         response = bedrock_client.list_foundation_models(byOutputModality="TEXT")
 


### PR DESCRIPTION
**Fixes:** #174 

**Description of changes:** fix Application Inference Profiles (AIP) mapping to include all profiles per model_id; switch to defaultdict(set) and emit all AIPs  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
