### PR TITLE
feat: add Claude Sonnet 4.5 support with global cross-region inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ OpenAI-compatible RESTful APIs for Amazon Bedrock
 
 ## What's New 🔥
 
-This project supports reasoning for both **Claude 3.7 Sonnet** and **DeepSeek R1**, check [How to Use](./docs/Usage.md#reasoning) for more details. You need to first run the Models API to refresh the model list.
+This project now supports **Claude Sonnet 4.5**, Anthropic's most intelligent model with enhanced coding capabilities and complex agent support, available via global cross-region inference.
+
+It also supports reasoning for both **Claude 3.7 Sonnet** and **DeepSeek R1**. Check [How to Use](./docs/Usage.md#reasoning) for more details. You need to first run the Models API to refresh the model list.
 
 ## Overview
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -51,6 +51,43 @@ curl -s $OPENAI_BASE_URL/models -H "Authorization: Bearer $OPENAI_API_KEY" | jq 
 ]
 ```
 
+## Chat Completions API
+
+### Basic Example with Claude Sonnet 4.5
+
+Claude Sonnet 4.5 is Anthropic's most intelligent model, excelling at coding, complex reasoning, and agent-based tasks. It's available via global cross-region inference profiles.
+
+**Example Request**
+
+```bash
+curl $OPENAI_BASE_URL/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d '{
+    "model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a Python function to calculate the Fibonacci sequence using dynamic programming."
+      }
+    ]
+  }'
+```
+
+**Example SDK Usage**
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+completion = client.chat.completions.create(
+    model="global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    messages=[{"role": "user", "content": "Write a Python function to calculate the Fibonacci sequence using dynamic programming."}],
+)
+
+print(completion.choices[0].message.content)
+```
+
 ## Embedding API
 
 **Important Notice**: Please carefully review the following points before using this proxy API for embedding.
@@ -451,10 +488,31 @@ for chunk in response:
 Extended thinking with tool use in Claude 4 models supports [interleaved thinking](https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html#claude-messages-extended-thinking-tool-use-interleaved) enables Claude 4 models to think between tool calls and run more sophisticated reasoning after receiving tool results. which is helpful for more complex agentic interactions.
 With interleaved thinking, the `budget_tokens` can exceed the `max_tokens` parameter because it represents the total budget across all thinking blocks within one assistant turn.
 
+**Supported Models**: Claude Sonnet 4, Claude Sonnet 4.5
 
 **Example Request**
 
-- Non-Streaming
+- Non-Streaming (Claude Sonnet 4.5)
+
+```bash
+curl http://127.0.0.1:8000/api/v1/chat/completions \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer bedrock" \
+-d '{
+"model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+"max_tokens": 2048,
+"messages": [{
+"role": "user",
+"content": "Explain how to implement a binary search tree with self-balancing capabilities."
+}],
+"extra_body": {
+"anthropic_beta": ["interleaved-thinking-2025-05-14"],
+"thinking": {"type": "enabled", "budget_tokens": 4096}
+}
+}'
+```
+
+- Non-Streaming (Claude Sonnet 4)
 
 ```bash
 curl http://127.0.0.1:8000/api/v1/chat/completions \
@@ -474,7 +532,28 @@ curl http://127.0.0.1:8000/api/v1/chat/completions \
 }'
 ```
 
-- Streaming
+- Streaming (Claude Sonnet 4.5)
+
+```bash
+curl http://127.0.0.1:8000/api/v1/chat/completions \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer bedrock" \
+-d '{
+"model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+"max_tokens": 2048,
+"messages": [{
+"role": "user",
+"content": "Explain how to implement a binary search tree with self-balancing capabilities."
+}],
+"stream": true,
+"extra_body": {
+"anthropic_beta": ["interleaved-thinking-2025-05-14"],
+"thinking": {"type": "enabled", "budget_tokens": 4096}
+}
+}'
+```
+
+- Streaming (Claude Sonnet 4)
 
 ```bash
 curl http://127.0.0.1:8000/api/v1/chat/completions \

--- a/docs/Usage_CN.md
+++ b/docs/Usage_CN.md
@@ -49,6 +49,42 @@ curl -s $OPENAI_BASE_URL/models -H "Authorization: Bearer $OPENAI_API_KEY" | jq 
 ]
 ```
 
+## Chat Completions API
+
+### Claude Sonnet 4.5 基础示例
+
+Claude Sonnet 4.5 是 Anthropic 最智能的模型，在编码、复杂推理和基于代理的任务方面表现出色。它通过全球跨区域推理配置文件提供。
+
+**Request 示例**
+
+```bash
+curl $OPENAI_BASE_URL/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d '{
+    "model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "messages": [
+      {
+        "role": "user",
+        "content": "编写一个使用动态规划计算斐波那契数列的Python函数。"
+      }
+    ]
+  }'
+```
+
+**SDK 使用示例**
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+completion = client.chat.completions.create(
+    model="global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    messages=[{"role": "user", "content": "编写一个使用动态规划计算斐波那契数列的Python函数。"}],
+)
+
+print(completion.choices[0].message.content)
+```
 
 ## Embedding API
 
@@ -452,10 +488,31 @@ Claude 4 模型支持借助工具使用的扩展思维功能（Extended Thinking
 
 在交错思考模式下，budget_tokens 可以超过 max_tokens 参数，因为它代表一次助手回合中所有思考块的总 Token 预算。
 
+**支持的模型**: Claude Sonnet 4, Claude Sonnet 4.5
 
 **Request 示例**
 
-- Non-Streaming
+- Non-Streaming (Claude Sonnet 4.5)
+
+```bash
+curl http://127.0.0.1:8000/api/v1/chat/completions \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer bedrock" \
+-d '{
+"model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+"max_tokens": 2048,
+"messages": [{
+"role": "user",
+"content": "解释如何实现一个具有自平衡功能的二叉搜索树。"
+}],
+"extra_body": {
+"anthropic_beta": ["interleaved-thinking-2025-05-14"],
+"thinking": {"type": "enabled", "budget_tokens": 4096}
+}
+}'
+```
+
+- Non-Streaming (Claude Sonnet 4)
 
 ```bash
 curl http://127.0.0.1:8000/api/v1/chat/completions \
@@ -475,7 +532,28 @@ curl http://127.0.0.1:8000/api/v1/chat/completions \
 }'
 ```
 
-- Streaming
+- Streaming (Claude Sonnet 4.5)
+
+```bash
+curl http://127.0.0.1:8000/api/v1/chat/completions \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer bedrock" \
+-d '{
+"model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+"max_tokens": 2048,
+"messages": [{
+"role": "user",
+"content": "解释如何实现一个具有自平衡功能的二叉搜索树。"
+}],
+"stream": true,
+"extra_body": {
+"anthropic_beta": ["interleaved-thinking-2025-05-14"],
+"thinking": {"type": "enabled", "budget_tokens": 4096}
+}
+}'
+```
+
+- Streaming (Claude Sonnet 4)
 
 ```bash
 curl http://127.0.0.1:8000/api/v1/chat/completions \


### PR DESCRIPTION
## Description

This PR adds comprehensive support for Claude Sonnet 4.5 (`global.anthropic.claude-sonnet-4-5-20250929-v1:0`), Anthropic's most intelligent model released on September 30, 2025.

**Fixes #179**

## Motivation and Context

Claude Sonnet 4.5 is now available in Amazon Bedrock via global cross-region inference profiles. This model offers:
- Enhanced coding capabilities
- Superior performance on complex reasoning tasks
- Improved agent-based workflows
- Support for interleaved thinking (extended thinking with tool use)

Without this PR, users cannot access Claude Sonnet 4.5 through the Bedrock Access Gateway, limiting their ability to leverage Anthropic's most capable model.

## Changes

### Core Functionality
- **Global cross-region inference profiles**: Added support for `global.*` prefix in `list_bedrock_models()` to discover models like `global.anthropic.claude-sonnet-4-5-20250929-v1:0`
- **Claude Sonnet 4.5 compatibility**: Fixed parameter validation - this model doesn't support both `temperature` and `topP` simultaneously
- **Extended thinking support**: Ensured `extra_body` parameter works correctly with interleaved thinking beta feature

### Documentation
- Updated README.md with Claude Sonnet 4.5 announcement in "What's New" section
- Added comprehensive Chat Completions examples in docs/Usage.md
- Added Interleaved thinking examples with proper usage patterns
- Added Chinese translations in docs/Usage_CN.md for all new content

## Testing

Tested against a deployed Bedrock Access Gateway instance:

✅ **Basic Chat Completions**
```bash
curl $OPENAI_BASE_URL/chat/completions \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{"model":"global.anthropic.claude-sonnet-4-5-20250929-v1:0","messages":[{"role":"user","content":"Hello"}]}'
```
✅ Model Discovery
```bash
curl $OPENAI_BASE_URL/models | jq '.data[] | select(.id | contains("4-5"))'
```
✅ Interleaved Thinking
```bash
curl $OPENAI_BASE_URL/chat/completions \
  -d '{"model":"global.anthropic.claude-sonnet-4-5-20250929-v1:0","extra_body":{"anthropic_beta":["interleaved-thinking-2025-05-14"],"thinking":{"type":"enabled","budget_tokens":2048}},...}'
```
## Types of changes
 - New feature (adds Claude Sonnet 4.5 support)
 - Documentation update
## Checklist
 - I am working against the latest source on the main branch
 - I have checked existing open and recently merged pull requests
 - My code follows the code style of this project
 -  I have updated the documentation accordingly
## Additional Notes
- Model ID Format: global.anthropic.claude-sonnet-4-5-20250929-v1:0 
- Breaking Changes: None - this is additive functionality only Deployment Note: After merging, users will need to call the /models endpoint to refresh their model list and discover the new Claude Sonnet 4.5 model