### PR TITLE
ECS container healthcheck without auth token

### DIFF
--- a/src/Dockerfile_ecs
+++ b/src/Dockerfile_ecs
@@ -17,6 +17,6 @@ USER appuser
 ENV PORT=8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/v1/models').read()"
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health').read()"
 
 CMD ["sh", "-c", "uvicorn api.app:app --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
The Existing ECS container [healthcheck](https://github.com/aws-samples/bedrock-access-gateway/blob/9cea7f9314df564eec5e1b1c8d14c1ec201aa43f/src/Dockerfile_ecs#L19-L20) fails  `403` because a recent change requires an `API_KEY` to be passed for `/api/v1/models`.

`{"detail":"Not authenticated"}`

*Issue #, if available:*

*Description of changes:*

- updated `Dockerfile_ecs` container `HEALTHCHECK` endpoint from `/api/v1/models` to `/health`, which now responds `200` successfully:

`{"status":"OK"}`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
