### PR TITLE
🐳 preload tiktoken encoding in Dockerfile_ecs

### DIFF
--- a/src/Dockerfile_ecs
+++ b/src/Dockerfile_ecs
@@ -14,6 +14,10 @@ RUN groupadd -r appuser && useradd -r -g appuser appuser && \
 
 USER appuser
 
+# Preload tiktoken encoding: https://github.com/aws-samples/bedrock-access-gateway/issues/118
+ENV TIKTOKEN_CACHE_DIR=/app/.cache/tiktoken
+RUN python3 -c 'import tiktoken_ext.openai_public as tke; tke.cl100k_base()'
+
 ENV PORT=8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \


### PR DESCRIPTION
**Issue:** #118

### Problem
Startup can fail in egress-restricted environments because `tiktoken` downloads `cl100k_base` from `openaipublic.blob.core.windows.net`.

### Changes
Preload the encoding during the image build (as the runtime user) and cache it under `/app/.cache/tiktoken`, removing the outbound dependency at startup. By this change, we expect improved reliability behind firewalls.

- `ENV TIKTOKEN_CACHE_DIR=/app/.cache/tiktoken`
- Run `tiktoken_ext.openai_public.cl100k_base()` **after** `USER appuser`

### Impact
Impact of this change should be ignorable.
Image size increased by only ~3 MB (377 MB → 380 MB), contains no runtime behavior change.

<img width="592" height="36" alt="Screenshot 2025-10-22 at 15 51 41" src="https://github.com/user-attachments/assets/1f1bb68b-18f0-4b85-b18a-1c5f47f314a0" />
