### PR TITLE
fix: Fix invalid cache_creation_tokens metric key

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -375,7 +375,7 @@ class BedrockModel(BaseChatModel):
 
         # Extract prompt caching metrics if available
         cache_read_tokens = usage.get("cacheReadInputTokens", 0)
-        cache_creation_tokens = usage.get("cacheCreationInputTokens", 0)
+        cache_creation_tokens = usage.get("cacheWriteInputTokens", 0)
 
         # Calculate actual prompt tokens
         # Bedrock's totalTokens includes all: inputTokens + cacheRead + cacheWrite + outputTokens
@@ -1035,7 +1035,7 @@ class BedrockModel(BaseChatModel):
 
                 # Extract prompt caching metrics if available
                 cache_read_tokens = usage_data.get("cacheReadInputTokens", 0)
-                cache_creation_tokens = usage_data.get("cacheCreationInputTokens", 0)
+                cache_creation_tokens = usage_data.get("cacheWriteInputTokens", 0)
 
                 # Create prompt_tokens_details if cache metrics are available
                 prompt_tokens_details = None


### PR DESCRIPTION
*Issue #, if available:*
The key `cacheCreationInputTokens` is incorrect.
We adopted part of your team’s codebase internally and noticed that prompt caching metrics weren’t working as expected.
To fix this issue, the key should be updated to `cacheWriteInputTokens`.

*Description of changes:*
See: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html#prompt-caching-get-started

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
