### PR TITLE
Fix healthcheck in Dockerfile_ecs

### DIFF
--- a/src/Dockerfile_ecs
+++ b/src/Dockerfile_ecs
@@ -21,6 +21,6 @@ RUN python3 -c 'import tiktoken_ext.openai_public as tke; tke.cl100k_base()'
 ENV PORT=8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health').read()"
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/health').read()"
 
 CMD ["sh", "-c", "uvicorn api.app:app --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
*Description of changes:*

The healthcheck in Dockerfile_ecs uses the hardcoded port instead of ENV setting. This was fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
