### PR TITLE
Fix:  set tool specification description to tool name when description is blank

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -1186,7 +1186,7 @@ class BedrockModel(BaseChatModel):
         return {
             "toolSpec": {
                 "name": func.name,
-                "description": func.description,
+                "description": func.description if func.description else func.name,
                 "inputSchema": {
                     "json": func.parameters,
                 },


### PR DESCRIPTION
*Issue #213 :*

*Description of changes:*
When working with cline in VSCode, user reported seeing these errors:

[ERROR] Stream error: 500: Parameter validation failed:
Invalid length for parameter toolConfig.tools[13].toolSpec.description, value: 0, valid min length: 1

Amazon Bedrock requires a description property of a tool specification to be > 1 length

https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_ToolSpecification.html

Rather than use a pydantic validator, i just added a simple inline to use the tool name as the description if necessary

Cline project has an issue under review:
https://github.com/cline/cline/issues/7696





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
