### PR TITLE
fix(deps): update fastapi and starlette for CVE-2025-62727

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
-fastapi==0.116.1
+fastapi==0.128.0
+starlette==0.49.1  # CVE-2025-62727: Fix ReDoS in Range header parsing
 pydantic==2.11.4
 uvicorn==0.29.0
 mangum==0.17.0


### PR DESCRIPTION
Update dependencies to fix HIGH severity ReDoS vulnerability:
- fastapi==0.128.0
- starlette==0.49.1

CVE-2025-62727 allows unauthenticated attackers to send crafted HTTP Range headers that trigger quadratic-time processing in FileResponse Range parsing, causing CPU exhaustion and DoS.

Fixes #215

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
