### PR TITLE
fix: preload tiktoken encoding in Dockerfile (Lambda)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -9,6 +9,10 @@ COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt -U --no-cache-dir
 
+# Preload tiktoken encoding: https://github.com/aws-samples/bedrock-access-gateway/issues/118
+ENV TIKTOKEN_CACHE_DIR=/var/task/.cache/tiktoken
+RUN python3 -c 'import tiktoken_ext.openai_public as tke; tke.cl100k_base()'
+
 # Lambda Web Adapter requires overriding the Lambda base image entrypoint
 # to run the web app directly instead of the Lambda runtime handler
 ENTRYPOINT []


### PR DESCRIPTION
*Issue #, if available:*

Related to #118

*Description of changes:*

PR #193 added tiktoken preloading to `Dockerfile_ecs` to resolve #118, but the same fix was not applied to the Lambda `Dockerfile`. This causes a `ConnectTimeout` error in network-restricted environments (e.g., Lambda deployed in a VPC without a NAT Gateway) when tiktoken attempts to download the `cl100k_base` encoding at runtime from `openaipublic.blob.core.windows.net`.

This PR adds the same tiktoken preloading to `src/Dockerfile`, caching the `cl100k_base` encoding at build time so no outbound internet access is required at runtime. The approach is consistent with `Dockerfile_ecs`.

**Changes:**
- Added `ENV TIKTOKEN_CACHE_DIR=/var/task/.cache/tiktoken`
- Added `RUN python3 -c 'import tiktoken_ext.openai_public as tke; tke.cl100k_base()'`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.