### PR TITLE
fix: preserve reasoning blocks for Claude tool-use follow-up turns

### DIFF
--- a/tests/test_thinking_tool_use.py
+++ b/tests/test_thinking_tool_use.py
@@ -1,0 +1,64 @@
+import os
+
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+os.environ.setdefault("ENABLE_CROSS_REGION_INFERENCE", "false")
+os.environ.setdefault("ENABLE_APPLICATION_INFERENCE_PROFILES", "false")
+
+from api.models.bedrock import BedrockModel
+from api.schema import AssistantMessage, ChatRequest, ResponseFunction, ToolCall, ToolMessage, UserMessage
+
+
+def test_parse_assistant_text_converts_think_tags_to_reasoning_blocks():
+    model = BedrockModel()
+
+    content = model._parse_assistant_text("<think>Plan first</think>Now answer")
+
+    assert content == [
+        {"reasoningContent": {"text": "Plan first"}},
+        {"text": "Now answer"},
+    ]
+
+
+def test_parse_assistant_text_preserves_unbalanced_think_tags_as_plain_text():
+    model = BedrockModel()
+
+    content = model._parse_assistant_text("<think>Plan first")
+
+    assert content == [{"text": "<think>Plan first"}]
+
+
+def test_parse_messages_keeps_reasoning_before_tool_use():
+    model = BedrockModel()
+
+    request = ChatRequest(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=[
+            UserMessage(content="How is the weather in New York?"),
+            AssistantMessage(
+                content="<think>Need weather tool lookup.</think>I will check now.",
+                tool_calls=[
+                    ToolCall(
+                        id="call_1",
+                        type="function",
+                        function=ResponseFunction(
+                            name="get_current_weather",
+                            arguments='{"city":"New York"}',
+                        ),
+                    )
+                ],
+            ),
+            ToolMessage(
+                tool_call_id="call_1",
+                content="Sunny and 24C.",
+            ),
+        ],
+    )
+
+    messages = model._parse_messages(request)
+
+    assert len(messages) == 3
+    assert messages[1]["role"] == "assistant"
+    assistant_content = messages[1]["content"]
+    assert assistant_content[0] == {"reasoningContent": {"text": "Need weather tool lookup."}}
+    assert any("toolUse" in block for block in assistant_content)
+


### PR DESCRIPTION
## Summary
Fixes #119 by preserving structured reasoning blocks in assistant turn history before tool-use blocks.

When clients send previous assistant output back as OpenAI-style text with `<think>...</think>`, the gateway previously forwarded that as plain `text`. For Claude reasoning + tool-use flows, Bedrock requires reasoning blocks to remain structured (`reasoningContent`) before `toolUse`/`toolResult` blocks.

## What changed
- `src/api/models/bedrock.py`
  - Added `_parse_assistant_text(...)` to convert `<think>...</think>` segments into Bedrock `reasoningContent` blocks.
  - Updated `_parse_content_parts(...)` to use this conversion for assistant text content (string or `TextContent` parts).
  - Preserved fallback behavior for malformed/unbalanced think tags by keeping the original text unchanged.

- `tests/test_thinking_tool_use.py`
  - Added regression tests for:
    - think-tag conversion to reasoning blocks,
    - malformed think-tag fallback,
    - end-to-end message reframing with reasoning + tool use ordering.

## Why this addresses the issue
This ensures assistant history passed to Bedrock keeps reasoning as structured blocks instead of plain text, matching Bedrock/Claude expectations for thinking mode across tool-use turns.

## Validation
- `PYTHONPATH=src AWS_EC2_METADATA_DISABLED=true ENABLE_CROSS_REGION_INFERENCE=false ENABLE_APPLICATION_INFERENCE_PROFILES=false python3 -m pytest -q tests/test_thinking_tool_use.py`
- `python3 -m ruff check src/api/models/bedrock.py tests/test_thinking_tool_use.py`
