### PR TITLE
feat: add Amazon Nova 2 multimodal embeddings support

### DIFF
--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -182,7 +182,7 @@ class EmbeddingsRequest(BaseModel):
     input: str | list[str] | Iterable[int | Iterable[int]]
     model: str
     encoding_format: Literal["float", "base64"] = "float"
-    dimensions: int | None = None  # not used.
+    dimensions: int | None = None  # Used by Nova embeddings; ignored by other models.
     user: str | None = None  # not used.
 
 


### PR DESCRIPTION
## Summary

- Adds `amazon.nova-2-multimodal-embeddings-v1:0` to `SUPPORTED_BEDROCK_EMBEDDING_MODELS`
- Implements `NovaEmbeddingsModel` using the `taskType`/`singleEmbeddingParams` request format from the [Nova 2 embeddings docs](https://docs.aws.amazon.com/nova/latest/nova2-userguide/embeddings.html)
- Supports batch inputs (one API call per text), custom `dimensions` (256/512/1024/2048/3072, default 3072), and `float`/`base64` encoding formats

## Test plan

Start the gateway:
```bash
cd src && uvicorn api.app:app --port 8000
```

Then run the following (requires `pip install openai`):

```python
import os
from openai import OpenAI

BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000/api/v1")
MODEL = "amazon.nova-2-multimodal-embeddings-v1:0"
client = OpenAI(base_url=BASE_URL, api_key=os.environ.get("AWS_BEDROCK_BEARER_TOKEN", "dummy"))

# Single text
resp = client.embeddings.create(model=MODEL, input="Hello, world!")
assert len(resp.data[0].embedding) == 3072
print(f"[PASS] single text -> dim={len(resp.data[0].embedding)}")

# Batch
resp = client.embeddings.create(model=MODEL, input=["semantic search", "vector database", "RAG pipeline"])
assert len(resp.data) == 3
print(f"[PASS] batch (3 texts) -> dim={len(resp.data[0].embedding)}")

# Custom dimensions
resp = client.embeddings.create(model=MODEL, input="test", dimensions=256)
assert len(resp.data[0].embedding) == 256
print(f"[PASS] custom dimensions -> dim={len(resp.data[0].embedding)}")

# base64 encoding
resp = client.embeddings.create(model=MODEL, input="base64 test", encoding_format="base64")
assert isinstance(resp.data[0].embedding, str)
print("[PASS] base64 encoding")

# Model listed
assert MODEL in [m.id for m in client.models.list().data]
print("[PASS] model listed in /models")
```
