### PR TITLE
Feature/logging overhaul

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -9,7 +9,7 @@ from fastapi.responses import PlainTextResponse
 from mangum import Mangum
 
 from api.routers import chat, embeddings, model
-from api.setting import API_ROUTE_PREFIX, DEBUG, DESCRIPTION, SUMMARY, TITLE, VERSION, TRACE
+from api.setting import API_ROUTE_PREFIX, DEBUG, DESCRIPTION, SUMMARY, TITLE, TRACE, TRACE_LEVEL, VERSION
 
 config = {
     "title": TITLE,
@@ -17,10 +17,6 @@ config = {
     "summary": SUMMARY,
     "version": VERSION,
 }
-
-# Register custom TRACE level (5) below DEBUG (10) for per-chunk streaming logs
-TRACE_LEVEL = 5
-logging.addLevelName(TRACE_LEVEL, "TRACE")
 
 # In ECS/Fargate, CloudWatch adds timestamps and metadata — use default format.
 # Outside ECS, add timestamp and level for human-readable local output.

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -2,7 +2,6 @@ import base64
 import json
 import logging
 
-TRACE_LEVEL = 5  # Custom level below DEBUG(10) for per-chunk streaming logs
 import re
 import time
 from abc import ABC
@@ -50,6 +49,7 @@ from api.setting import (
     ENABLE_CROSS_REGION_INFERENCE,
     ENABLE_APPLICATION_INFERENCE_PROFILES,
     ENABLE_PROMPT_CACHING,
+    TRACE_LEVEL,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -8,7 +8,7 @@ from fastapi.responses import StreamingResponse
 from api.auth import api_key_auth
 from api.models.bedrock import BedrockModel
 from api.schema import ChatRequest, ChatResponse, ChatStreamResponse, Error
-from api.setting import DEFAULT_MODEL, USAGE_USER_HEADER, USAGE_CHAT_ID_HEADER
+from api.setting import DEFAULT_MODEL, TRACE_LEVEL, USAGE_USER_HEADER, USAGE_CHAT_ID_HEADER
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,6 @@ async def chat_completions(
         ),
     ],
 ):
-    TRACE_LEVEL = 5
     if logger.isEnabledFor(TRACE_LEVEL):
         logger.log(
             TRACE_LEVEL,

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 API_ROUTE_PREFIX = os.environ.get("API_ROUTE_PREFIX", "/api/v1")
@@ -11,6 +12,11 @@ Use OpenAI-Compatible RESTful APIs for Amazon Bedrock models.
 
 DEBUG = os.environ.get("DEBUG", "false").lower() != "false"
 TRACE = os.environ.get("TRACE", "false").lower() != "false"
+
+# Custom log level below DEBUG(10) for per-chunk streaming logs.
+# Registered once here so every module can import TRACE_LEVEL.
+TRACE_LEVEL = 5
+logging.addLevelName(TRACE_LEVEL, "TRACE")
 AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
 DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0")
 DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3")


### PR DESCRIPTION
*Issue #225*

*Description of changes:*
**1. Centralise TRACE_LEVEL in `setting.py`**

Register the custom TRACE level (5, below DEBUG at 10) once in `setting.py` and import it everywhere:

```python
# setting.py
TRACE_LEVEL = 5
logging.addLevelName(TRACE_LEVEL, "TRACE")
```

**2. Three-tier logging**

- **INFO** (default) — startup, errors, CORS warnings, and USAGE summary per request
- **DEBUG** (`DEBUG=true`) — request/response details, model resolution, tool calls, cache points
- **TRACE** (`TRACE=true`) — per-chunk streaming data, raw request/response bodies, request headers

Only the `api` logger hierarchy is affected — boto3/botocore/urllib3 stay at INFO:

```python
if TRACE or DEBUG:
    logging.getLogger("api").setLevel(TRACE_LEVEL if TRACE else logging.DEBUG)
```

**3. ECS-aware log format**

Detect ECS/Fargate via `ECS_CONTAINER_METADATA_URI` and skip log formatting (CloudWatch adds its own timestamps and metadata). Outside ECS, use human-readable format:

```python
_log_kwargs = {"level": logging.INFO}
if not os.environ.get("ECS_CONTAINER_METADATA_URI"):
    _log_kwargs["format"] = "%(asctime)s [%(levelname)s] %(message)s"
logging.basicConfig(**_log_kwargs)
```

**4. Lazy `%s` formatting and `isEnabledFor` guards**

All `logger.debug()` calls use `%s` lazy formatting instead of f-strings. Expensive debug operations (JSON serialisation, dict formatting) are guarded with `isEnabledFor`:

```python
# Before (eager f-string evaluation even when debug is off):
logger.debug(f"Resolved {model_id} → {result}")

# After (lazy — no string formatting unless DEBUG is enabled):
logger.debug("Resolved %s -> %s", model_id, result)

# Expensive operations guarded:
if logger.isEnabledFor(TRACE_LEVEL):
    logger.log(TRACE_LEVEL, "Request body: %s",
               json.dumps(chat_request.model_dump(), indent=2, default=str))
```

**5. Per-request USAGE logging (INFO level)**

A structured one-line summary logged after every request completes:

```
USAGE | user=admin@example.com | chat=abc-123 | model=claude-sonnet-4 | max_tokens=4096 | in=1523 | out=847 | cache_write=0 | cache_read=1200 | ua=OpenAI/Python
```

User and chat ID are extracted from configurable HTTP headers (empty defaults — only active when configured):

```bash
# Optional: configure headers from your upstream proxy
export USAGE_USER_HEADER=x-openwebui-user-email
export USAGE_CHAT_ID_HEADER=x-openwebui-chat-id
```

**6. Improved validation error handler**

The validation exception handler now logs error count at WARNING level and optionally logs the rejected request body at TRACE level:

```python
@app.exception_handler(RequestValidationError)
async def validation_exception_handler(request, exc):
    error_count = len(exc.errors()) if hasattr(exc, 'errors') else 'unknown'
    logger.warning("Request validation failed: %s %s - %s error(s)",
                   request.method, request.url.path, error_count)
    if logger.isEnabledFor(TRACE_LEVEL):
        body = (await request.body()).decode("utf-8", errors="replace")[:2000]
        logger.log(TRACE_LEVEL, "Rejected request body: %s", body)
    return PlainTextResponse(str(exc), status_code=400)
```

### New environment variables

| Variable | Default | Description |
|----------|---------|-------------|
| `TRACE` | `false` | Enable TRACE-level logging (very verbose) |
| `USAGE_USER_HEADER` | `""` | HTTP header for user identity in USAGE lines |
| `USAGE_CHAT_ID_HEADER` | `""` | HTTP header for chat/session ID in USAGE lines |

**Files:** `src/api/setting.py`, `src/api/app.py`, `src/api/routers/chat.py`, `src/api/models/bedrock.py`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
