### PR TITLE
fix: increase default max_tokens from 2048 to 128000

### DIFF
--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -106,7 +106,7 @@ class ChatRequest(BaseModel):
     temperature: float | None = Field(default=None, le=2.0, ge=0.0)
     top_p: float | None = Field(default=None, le=1.0, ge=0.0)
     user: str | None = None  # Not used
-    max_tokens: int | None = 2048
+    max_tokens: int | None = 128000
     max_completion_tokens: int | None = None
     reasoning_effort: Literal["low", "medium", "high"] | None = None
     n: int | None = 1  # Not used


### PR DESCRIPTION
## Summary
- Increases the default `max_tokens` in `ChatRequest` schema from 2048 to 128000

## Problem
When clients don't explicitly send `max_tokens` (common with agent frameworks like Hermes Agent), the gateway defaults to 2048. For reasoning models like Claude Opus 4.6, the model exhausts the entire 2048-token budget on extended thinking and has no tokens left for the actual response, causing `finish_reason: "length"` truncation errors.

This is a silent failure — the client gets a truncated/empty response with no clear indication that the default was too low.

## Fix
Set the default to 128,000 which matches the Bedrock max output token limit for Claude Opus 4.6. Models that support less will be capped by Bedrock itself. This is a safe change because:
- Bedrock enforces per-model output limits regardless of what's requested
- Clients that explicitly set `max_tokens` are unaffected
- The previous default of 2048 was too low for any reasoning-capable model

## Test plan
- [x] Tested with Claude Opus 4.6 (`eu.anthropic.claude-opus-4-6-v1`) — responses complete successfully
- [x] Tested with explicit `max_tokens` values (4096, 32768, 128000) — all work
- [x] Tested without `max_tokens` — now defaults to 128000 instead of 2048
- [x] Verified `finish_reason: "stop"` on all tests