### PR TITLE
Add claude-sonnet-4-6 to TEMPERATURE_TOPP_CONFLICT_MODELS list

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -95,6 +95,7 @@ profile_metadata = {}
 # When both are provided, temperature takes precedence and topP is removed
 TEMPERATURE_TOPP_CONFLICT_MODELS = {
     "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
     "claude-haiku-4-5",
     "claude-opus-4-5",
 }
@@ -784,7 +785,7 @@ class BedrockModel(BaseChatModel):
         if chat_request.top_p is not None:
             inference_config["topP"] = chat_request.top_p
 
-        # Some models (Claude Sonnet 4.5, Haiku 4.5) don't support both temperature and topP
+        # Some models (Claude Sonnet 4.5, Claude Sonnet 4.6, Haiku 4.5) don't support both temperature and topP
         # When both are provided, keep temperature and remove topP
         # Resolve profile to underlying model for feature detection
         resolved_model = self._resolve_to_foundation_model(chat_request.model)


### PR DESCRIPTION
*Description of changes:*

  ---
  Summary

  - Add claude-sonnet-4-6 to the TEMPERATURE_TOPP_CONFLICT_MODELS set in bedrock.py
  - Update the inline comment to reflect that Claude Sonnet 4.6 also does not support simultaneous temperature and topP parameters

  Background

  Some Bedrock-hosted Claude models reject requests where both temperature and topP inference parameters are provided. The gateway handles this by detecting the model at request time and dropping topP when temperature is also present. Claude Sonnet 4.6 shares this constraint with other models in the 4.x family (Sonnet 4.5, Haiku 4.5, Opus 4.5), so it needs to be included in the conflict list.

Fix was tested with model `anthropic.claude-sonnet-4-6` and it works fine.