### PR TITLE
fix: display inferenceProfileName instead of ARN for application profiles in /models

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -162,11 +162,15 @@ def list_bedrock_models() -> dict:
                         # Extract model ID from ARN (works for both foundation models and cross-region profiles)
                         model_id = model_arn.split('/')[-1] if '/' in model_arn else model_arn
 
+                        profile_name = profile.get("inferenceProfileName", "")
+                        profile_key = profile_name or profile_arn
+
                         # Store in unified profile metadata for feature detection
-                        profile_metadata[profile_arn] = {
+                        profile_metadata[profile_key] = {
                             "underlying_model_id": model_id,
                             "profile_type": "APPLICATION",
-                            "profile_name": profile.get("inferenceProfileName", ""),
+                            "profile_name": profile_name,
+                            "profile_arn": profile_arn,
                         }
                     except Exception as e:
                         logger.warning(f"Error processing application profile: {e}")
@@ -191,9 +195,9 @@ def list_bedrock_models() -> dict:
                 model_list[model_id] = {"modalities": input_modalities}
 
             # Add all inference profiles (cross-region and application) for this model
-            for profile_id, metadata in profile_metadata.items():
+            for profile_key, metadata in profile_metadata.items():
                 if metadata.get("underlying_model_id") == model_id:
-                    model_list[profile_id] = {"modalities": input_modalities}
+                    model_list[profile_key] = {"modalities": input_modalities}
 
     except Exception as e:
         logger.error(f"Unable to list models: {str(e)}")
@@ -248,20 +252,28 @@ class BedrockModel(BaseChatModel):
                 detail=error,
             )
 
+    @staticmethod
+    def _resolve_model_id_for_api(model_id: str) -> str:
+        """Resolve a profile name to its ARN for the Bedrock API call."""
+        metadata = profile_metadata.get(model_id)
+        if metadata and "profile_arn" in metadata:
+            return metadata["profile_arn"]
+        return model_id
+
     def _resolve_to_foundation_model(self, model_id: str) -> str:
         """
         Resolve any model identifier to foundation model ID for feature detection.
 
         Handles:
         - Cross-region profiles (us.*, eu.*, apac.*, global.*)
-        - Application profiles (arn:aws:bedrock:...:application-inference-profile/...)
+        - Application profiles (by name or ARN)
         - Foundation models (pass through unchanged)
 
         No pattern matching needed - just dictionary lookup.
         Unknown identifiers pass through unchanged (graceful fallback).
 
         Args:
-            model_id: Can be foundation model ID, cross-region profile, or app profile ARN
+            model_id: Can be foundation model ID, cross-region profile, app profile name, or ARN
 
         Returns:
             Foundation model ID if mapping exists, otherwise original model_id
@@ -788,7 +800,7 @@ class BedrockModel(BaseChatModel):
             inference_config["stopSequences"] = stop
 
         args = {
-            "modelId": chat_request.model,
+            "modelId": self._resolve_model_id_for_api(chat_request.model),
             "messages": messages,
             "system": system_prompts,
             "inferenceConfig": inference_config,


### PR DESCRIPTION
## Summary

- Use human-readable `inferenceProfileName` instead of ARN as the model ID for application inference profiles in the `/models` API
- Resolve profile names back to ARNs before Bedrock API calls
- Backward compatible with cross-region profiles (unchanged)

## Problem

Application inference profiles were displayed with their full ARN in the `/models` response:
```json
{"id": "arn:aws:bedrock:eu-central-1:123456789:application-inference-profile/0h48dnxmrxnl"}
```

This made it difficult for users to identify and select profiles in clients like OpenWebUI, where the ARN is opaque and unhelpful.

## Solution

**Before:**
```
GET /models → id: "arn:aws:bedrock:...:application-inference-profile/..."
User sends: model: "arn:aws:bedrock:..."
Bedrock call: modelId: "arn:aws:bedrock:..."
```

**After:**
```
GET /models → id: "my-team-claude"
User sends: model: "my-team-claude"
Bedrock call: modelId: "arn:aws:bedrock:..."  (resolved via _resolve_model_id_for_api)
```

Changes in `src/api/models/bedrock.py`:
1. Key `profile_metadata` by `inferenceProfileName` (falls back to ARN if name is empty)
2. Store `profile_arn` in the metadata for API call resolution
3. Add `_resolve_model_id_for_api()` static method to map profile names back to ARNs
4. Apply resolution in `_prepare_converse_api_params` before the Bedrock `converse` call

Cross-region profiles (SYSTEM_DEFINED) are unaffected — they continue to use `inferenceProfileId`.

## Test Plan

- [x] Code parses correctly (AST verification)
- [x] No existing test suite in this repo
- [x] `_resolve_model_id_for_api` is a no-op for non-application-profile models (backward compatible)
- [x] Falls back to ARN if `inferenceProfileName` is empty

## Compatibility

- [x] No breaking changes for cross-region profiles
- [x] No breaking changes for foundation model IDs
- [x] Application profile users will see friendly names instead of ARNs

Fixes #218