### PR TITLE
fix: use None as default for max_tokens and prefer max_completion_tokens

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -368,6 +368,8 @@ You can try it with different questions, such as:
 - For DeepSeek R1, you don't need additional reasoning_effort parameter, otherwise, you may get an error.
 - The reasoning response (CoT, thoughts) is added in an additional tag 'reasoning_content' which is not officially supported by OpenAI. This is to follow [Deepseek Reasoning Model](https://api-docs.deepseek.com/guides/reasoning_model#api-example). This may be changed in the future.
 
+> **Note**: Omitting `max_tokens` (or `max_completion_tokens`) now allows Bedrock to use the model's native maximum output (e.g., 64K for Claude Sonnet 4) rather than the previous 2048 implicit cap. Please set `max_tokens` explicitly if you need to control costs or latency.
+
 **Example Request**
 
 - Claude 3.7 Sonnet

--- a/docs/Usage_CN.md
+++ b/docs/Usage_CN.md
@@ -365,6 +365,8 @@ You can try it with different questions, such as:
 - Deepseek R1 会自动使用推理模式，不需要在中传递额外的 reasoning_effort 参数（否则会报错）
 - 推理结果（思维链结果、思考过程）被添加到名为 'reasoning_content' 的额外标签中，这不是 OpenAI 官方支持的格式。此设计遵循 [Deepseek Reasoning Model](https://api-docs.deepseek.com/guides/reasoning_model#api-example)  的规范。未来可能会有所变动。
 
+> **注意**: 现在如果省略 `max_tokens` （或 `max_completion_tokens`），Bedrock 将使用模型的原生最大输出限制（例如，Claude Sonnet 4 为 64K），而不是之前的 2048 隐式上限。如果您需要控制成本或延迟，请明确设置 `max_tokens`。
+
 **Request 示例**
 
 - Claude 3.7 Sonnet

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -832,7 +832,7 @@ class BedrockModel(BaseChatModel):
                     )
                 # unset topP - Not supported
                 inference_config.pop("topP", None)
-                
+
                 budget_tokens = self._calc_budget_tokens(
                     effective_max_tokens, chat_request.reasoning_effort
                 )

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -774,10 +774,16 @@ class BedrockModel(BaseChatModel):
         messages = self._parse_messages(chat_request)
         system_prompts = self._parse_system_prompts(chat_request)
 
+        effective_max_tokens = (
+            chat_request.max_completion_tokens
+            if chat_request.max_completion_tokens is not None
+            else chat_request.max_tokens
+        )
+
         # Base inference parameters.
-        inference_config = {
-            "maxTokens": chat_request.max_tokens,
-        }
+        inference_config = {}
+        if effective_max_tokens is not None:
+            inference_config["maxTokens"] = effective_max_tokens
 
         # Only include optional parameters when specified
         if chat_request.temperature is not None:
@@ -819,18 +825,17 @@ class BedrockModel(BaseChatModel):
 
             if "anthropic.claude" in model_lower:
                 # Claude format: reasoning_config = object with budget_tokens
-                max_tokens = (
-                    chat_request.max_completion_tokens
-                    if chat_request.max_completion_tokens
-                    else chat_request.max_tokens
-                )
-                budget_tokens = self._calc_budget_tokens(
-                    max_tokens, chat_request.reasoning_effort
-                )
-                inference_config["maxTokens"] = max_tokens
+                if effective_max_tokens is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="max_tokens or max_completion_tokens must be set when using reasoning_effort with Claude models",
+                    )
                 # unset topP - Not supported
                 inference_config.pop("topP", None)
-
+                
+                budget_tokens = self._calc_budget_tokens(
+                    effective_max_tokens, chat_request.reasoning_effort
+                )
                 args["additionalModelRequestFields"] = {
                     "reasoning_config": {"type": "enabled", "budget_tokens": budget_tokens}
                 }

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -106,8 +106,8 @@ class ChatRequest(BaseModel):
     temperature: float | None = Field(default=None, le=2.0, ge=0.0)
     top_p: float | None = Field(default=None, le=1.0, ge=0.0)
     user: str | None = None  # Not used
-    max_tokens: int | None = 2048
-    max_completion_tokens: int | None = None
+    max_tokens: int | None = Field(default=None, ge=1)
+    max_completion_tokens: int | None = Field(default=None, ge=1)
     reasoning_effort: Literal["low", "medium", "high"] | None = None
     n: int | None = 1  # Not used
     tools: list[Tool] | None = None


### PR DESCRIPTION
*Issue #, if available:*
#227 (This PR also supersedes PR #228)

*Description of changes:*
This PR addresses the issue with `max_completion_tokens` and fully implements the maintainer's (@zxkane) feedback from the stale PR #228.

**Key Changes:**
* Removed the hardcoded `2048` default. Both `max_tokens` and `max_completion_tokens` now default to `None` with Pydantic `ge=1` validation.
* Updated `inference_config` logic to safely prefer `max_completion_tokens` over `max_tokens` using an `is not None` check, preventing `0` from being wrongly evaluated as Falsy.
* Omitted the `maxTokens` key entirely from `inference_config` if `effective_max_tokens` is `None` to prevent Bedrock API `ParamValidationError`.
* Added explicit `HTTPException` validation for Claude reasoning models when token limits are missing.


**⚠️ Behavior Change**

Clients that previously omitted `max_tokens` were implicitly capped at 2048. 
After this PR, omitting `max_tokens` lets Bedrock use the model's native maximum output (e.g., 64K for Claude Sonnet 4), consistent with both the OpenAI API and the Bedrock Converse API defaults.

Clients relying on the implicit 2048 cap should now set `max_tokens=2048` explicitly. 
This aligns with the direction the maintainer suggested in the review on #228 ("the default here should arguably be `None` rather than `DEFAULT_MAX_TOKENS`").

Thank you to @dcox761 for the initial work on #228.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.