### PR TITLE
feat: Add ACCEPT_ALL_OPENAI_KEY to disable authentication via OpenAI Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,12 @@ uvicorn api.app:app --host 0.0.0.0 --port 8000
 
 The API base url should look like `http://localhost:8000/api/v1`.
 
+You can disable the OpenAI key authentication entirely by setting the env var, `ACCEPT_ALL_OPENAI_KEY` to true and run the app, or run the `runlocal.sh` script from the `src` folder:
+
+```bash
+bash runlocal.sh
+```
+
 ### Any performance sacrifice or latency increase by using the proxy APIs
 
 Compared with direct AWS SDK calls, the proxy architecture will add some latency. The default API Gateway + Lambda deployment provides good streaming performance with Lambda response streaming.

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -7,31 +7,39 @@ from botocore.exceptions import ClientError
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-api_key_param = os.environ.get("API_KEY_PARAM_NAME")
-api_key_secret_arn = os.environ.get("API_KEY_SECRET_ARN")
-api_key_env = os.environ.get("API_KEY")
-if api_key_param:
-    # For backward compatibility.
-    # Please now use secrets manager instead.
-    ssm = boto3.client("ssm")
-    api_key = ssm.get_parameter(Name=api_key_param, WithDecryption=True)["Parameter"]["Value"]
-elif api_key_secret_arn:
-    sm = boto3.client("secretsmanager")
-    try:
-        response = sm.get_secret_value(SecretId=api_key_secret_arn)
-        if "SecretString" in response:
-            secret = json.loads(response["SecretString"])
-            api_key = secret["api_key"]
-    except ClientError:
-        raise RuntimeError("Unable to retrieve API KEY, please ensure the secret ARN is correct")
-    except KeyError:
-        raise RuntimeError('Please ensure the secret contains a "api_key" field')
-elif api_key_env:
-    api_key = api_key_env
+from api.setting import ACCEPT_ALL_OPENAI_KEY
+
+api_key = None  # Initialize to None
+
+if not ACCEPT_ALL_OPENAI_KEY:
+    api_key_param = os.environ.get("API_KEY_PARAM_NAME")
+    api_key_secret_arn = os.environ.get("API_KEY_SECRET_ARN")
+    api_key_env = os.environ.get("API_KEY")
+    if api_key_param:
+        # For backward compatibility.
+        # Please now use secrets manager instead.
+        ssm = boto3.client("ssm")
+        api_key = ssm.get_parameter(Name=api_key_param, WithDecryption=True)["Parameter"]["Value"]
+    elif api_key_secret_arn:
+        sm = boto3.client("secretsmanager")
+        try:
+            response = sm.get_secret_value(SecretId=api_key_secret_arn)
+            if "SecretString" in response:
+                secret = json.loads(response["SecretString"])
+                api_key = secret["api_key"]
+        except ClientError:
+            raise RuntimeError("Unable to retrieve API KEY, please ensure the secret ARN is correct")
+        except KeyError:
+            raise RuntimeError('Please ensure the secret contains a "api_key" field')
+    elif api_key_env:
+        api_key = api_key_env
+    else:
+        raise RuntimeError(
+            "API Key is not configured. Please set up your API Key."
+        )
 else:
-    raise RuntimeError(
-        "API Key is not configured. Please set up your API Key."
-    )
+    # In local mode, no API key needed
+    api_key = None
 
 security = HTTPBearer()
 
@@ -39,5 +47,9 @@ security = HTTPBearer()
 def api_key_auth(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
 ):
+    # In local development mode, accept any API key
+    if ACCEPT_ALL_OPENAI_KEY:
+        return
+
     if credentials.credentials != api_key:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API Key")

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -16,3 +16,4 @@ DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embe
 ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
 ENABLE_APPLICATION_INFERENCE_PROFILES = os.environ.get("ENABLE_APPLICATION_INFERENCE_PROFILES", "true").lower() != "false"
 ENABLE_PROMPT_CACHING = os.environ.get("ENABLE_PROMPT_CACHING", "false").lower() != "false"
+ACCEPT_ALL_OPENAI_KEY = os.environ.get("ACCEPT_ALL_OPENAI_KEY", "false").lower() != "false"

--- a/src/runlocal.sh
+++ b/src/runlocal.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Prerequisite: Authenticate to AWS via access keys or profile. 
+# 
+# Runs the uv app with OPENAI_BASE_URL set to http://127.0.0.1:8080/api/v1, and OPENAI_API_KEY set to arbitrary string without validating the key.
+#
+# Tests with: 
+# curl $OPENAI_BASE_URL/chat/completions \             
+#   -H "Content-Type: application/json" \
+#   -H "Authorization: Bearer $OPENAI_API_KEY" \
+#   -d '{
+#     "messages": [
+#       {
+#         "role": "user",
+#         "content": "Hello!"
+#       }
+#     ]
+#   }'
+#
+
+# Model selection
+export DEFAULT_MODEL=${DEFAULT_MODEL:-"us.anthropic.claude-sonnet-4-5-20250929-v1:0"}
+
+export OPENAI_BASE_URL=http://127.0.0.1:8080/api/v1
+export OPENAI_API_KEY=accept_all_keys
+
+export ACCEPT_ALL_OPENAI_KEY=true
+
+python -c 'import tiktoken_ext.openai_public as tke; tke.cl100k_base()'
+
+# Runs the uv app
+python -m uvicorn api.app:app --host 127.0.0.1 --port 8080


### PR DESCRIPTION
Add ACCEPT_ALL_OPENAI_KEY to disable authentication via OpenAI key for local run and added runlocal.sh script.

*Issue #, if available:*
Run without having to use secret manager and without validating the OpenAI key. Meant to be used locally.

*Description of changes:*
Added env var, ACCEPT_ALL_OPENAI_KEY to disable authentication via OpenAI key for requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
