### PR TITLE
fix(docker): upgrade base image OS packages to pick up CVE fixes

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,9 @@
 FROM public.ecr.aws/lambda/python:3.12
 
+# Apply the latest OS security patches available at build time so rebuilt
+# images pick up CVE fixes that have not yet rolled into the base image.
+RUN dnf upgrade -y && dnf clean all
+
 # Add Lambda Web Adapter for API Gateway response streaming
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
 

--- a/src/Dockerfile_ecs
+++ b/src/Dockerfile_ecs
@@ -1,5 +1,12 @@
 FROM public.ecr.aws/docker/library/python:3.13-slim
 
+# Apply the latest OS security patches available at build time so rebuilt
+# images pick up CVE fixes that have not yet rolled into the base image.
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY ./requirements.txt /app/requirements.txt


### PR DESCRIPTION
## Summary

Add a single OS-level package upgrade step at the top of both container images so each rebuild picks up the security patches that the OS vendor has shipped after the upstream Python base image was last rebuilt:

- `src/Dockerfile` (Lambda, `public.ecr.aws/lambda/python:3.12`, AL2023): `dnf upgrade -y && dnf clean all`
- `src/Dockerfile_ecs` (`public.ecr.aws/docker/library/python:3.13-slim`, Debian 13): `apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*`

## Why

Image scanners (ECR enhanced scanning, Inspector, etc.) flag both published images for OS-level CVEs in `openssl`, `glibc`, `dpkg`, and `sqlite3` whenever Debian or AL2023 publishes a fix faster than the Python base image rebuild cadence. Today neither Dockerfile runs any package upgrade, so a fresh `docker build` carries whatever was in the Python image at the time it was published.

For example, at the time of writing, the unpatched `python:3.13-slim` carries:

| Package | Installed | Advisory fixed-in |
|---|---|---|
| openssl / libssl3t64 | 3.5.4-1~deb13u2 | 3.5.5-1~deb13u2 (CVE-2026-31789, -31790, -28387/-88/-89/-90, -2673) |
| glibc (libc6) | 2.41-12+deb13u1 | 2.41-12+deb13u2 (CVE-2026-0861, -0915, -2025-15281) |
| dpkg | 1.22.21 | 1.22.22 (CVE-2026-2219) |
| libsqlite3-0 | 3.46.1-7 | 3.46.1-7+deb13u1 (CVE-2025-7709) |

After this change, a rebuild produces an image with all of the above on the `+deb13u2` / `3.5.5` lines.

## Test plan

- [x] `docker buildx build --platform linux/arm64 --pull --no-cache -f src/Dockerfile_ecs src/` succeeds
- [x] `docker buildx build --platform linux/arm64 --pull --no-cache -f src/Dockerfile src/` succeeds
- [x] Resulting ECS image: `dpkg -l` shows `openssl 3.5.5-1~deb13u2`, `libc6 2.41-12+deb13u2`, `dpkg 1.22.22`, `libsqlite3-0 3.46.1-7+deb13u1`
- [x] Resulting Lambda image: `rpm -qa` shows `glibc-2.34-231.amzn2023.0.3`, `openssl-fips-provider-latest-3.5.5-1.amzn2023.0.4`, `sqlite-libs-3.40.0-1.amzn2023.0.7`
- [x] Same image deployed to a Fargate service; ALB target group reports healthy after rolling deployment.

## Notes

- Image size grows by a few MB (the deltas of upgraded packages). The `rm -rf /var/lib/apt/lists/*` and `dnf clean all` keep the layer small.
- This makes builds non-reproducible by date (each rebuild may pick up different patch versions). That is the intended behaviour for a security-baseline upgrade and is the recommended pattern in [Dockerfile best practices](https://docs.docker.com/build/building/best-practices/#apt-get).