### PR TITLE
fix: add missing handler for Titan Embeddings G1 (amazon.titan-embed-text-v1)

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -1513,7 +1513,7 @@ def get_embeddings_model(model_id: str) -> BedrockEmbeddingsModel:
     match model_name:
         case "Cohere Embed Multilingual" | "Cohere Embed English":
             return CohereEmbeddingsModel()
-        case "Titan Embeddings G2 - Text":
+        case "Titan Embeddings G1 - Text" | "Titan Embeddings G2 - Text":
             return TitanEmbeddingsModel()
         case "Nova Multimodal Embeddings V2":
             return NovaEmbeddingsModel()


### PR DESCRIPTION
## Problem

PR #152 added `amazon.titan-embed-text-v1` to `SUPPORTED_BEDROCK_EMBEDDING_MODELS` but did not add a matching case in `get_embeddings_model()`. This causes a `400 Unsupported embedding model id` error when users try to use the v1 model for embeddings.

## Fix

Add `"Titan Embeddings G1 - Text"` to the existing match case that returns `TitanEmbeddingsModel()`. The `TitanEmbeddingsModel` class already supports the v1 request/response format (same `inputText`/`embedding` structure as v2).

## Change

```python
# Before
case "Titan Embeddings G2 - Text":
    return TitanEmbeddingsModel()

# After  
case "Titan Embeddings G1 - Text" | "Titan Embeddings G2 - Text":
    return TitanEmbeddingsModel()
```

## Testing

Verified that calling `/v1/embeddings` with `model: amazon.titan-embed-text-v1` returns a 400 error without this fix, and that the `TitanEmbeddingsModel` class handles the v1 format correctly (same `inputText` request body and `embedding` response field).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.