### PR TITLE
fix: drop orphan tool_use / tool_result pairs before Converse translation

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -527,6 +527,83 @@ class BedrockModel(BaseChatModel):
 
         return system_prompts
 
+    def _sanitize_tool_pairs(self, openai_messages: list) -> list:
+        """Drop orphan ``tool_calls``/``ToolMessage`` items.
+
+        Bedrock's Converse API rejects message sequences where a ``toolUse``
+        block has no matching ``toolResult`` (or vice versa) with a
+        ``ValidationException``. The OpenAI history coming from clients can
+        become unbalanced when the conversation is rewritten on the client
+        side, leaving orphan assistant ``tool_calls`` whose paired
+        ``ToolMessage`` entries were dropped.
+
+        This pre-pass keeps only those tool_call ids that have BOTH a
+        ``tool_calls`` entry on an assistant message AND a corresponding
+        ``ToolMessage`` later in the history. Anything else is removed before
+        the message list is translated to Bedrock blocks, so the gateway
+        always emits a balanced sequence regardless of the client's behaviour.
+
+        :param openai_messages: messages exactly as received from the client.
+        :return: a new list with orphan tool_use / tool_result entries removed.
+        """
+        # First pass: collect every tool_call_id that has a matching tool result.
+        result_ids: set[str] = set()
+        call_ids: set[str] = set()
+        for msg in openai_messages:
+            if isinstance(msg, ToolMessage) and msg.tool_call_id:
+                result_ids.add(msg.tool_call_id)
+            elif isinstance(msg, AssistantMessage) and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    if tc.id:
+                        call_ids.add(tc.id)
+
+        paired_ids = call_ids & result_ids
+        orphan_calls = call_ids - result_ids
+        orphan_results = result_ids - call_ids
+
+        if not orphan_calls and not orphan_results:
+            return openai_messages
+
+        if DEBUG:
+            logger.info(
+                "Sanitising orphan tool pairs: orphan_calls=%s orphan_results=%s",
+                sorted(orphan_calls),
+                sorted(orphan_results),
+            )
+
+        sanitized: list = []
+        for msg in openai_messages:
+            if isinstance(msg, ToolMessage):
+                # Drop tool results that have no matching tool_call.
+                if msg.tool_call_id in paired_ids:
+                    sanitized.append(msg)
+                continue
+
+            if isinstance(msg, AssistantMessage) and msg.tool_calls:
+                kept_calls = [
+                    tc for tc in msg.tool_calls
+                    if tc.id and tc.id in paired_ids
+                ]
+                # Preserve the assistant message itself when it still carries
+                # text content; only drop it entirely when the only payload
+                # was orphaned tool_calls.
+                has_text = (
+                    (isinstance(msg.content, str) and msg.content.strip() != "")
+                    or (isinstance(msg.content, list) and len(msg.content) > 0)
+                )
+                if not kept_calls and not has_text:
+                    continue
+                if kept_calls != msg.tool_calls:
+                    msg = msg.model_copy(
+                        update={"tool_calls": kept_calls or None}
+                    )
+                sanitized.append(msg)
+                continue
+
+            sanitized.append(msg)
+
+        return sanitized
+
     def _parse_messages(self, chat_request: ChatRequest) -> list[dict]:
         """
         Converse API only support user and assistant messages.
@@ -540,7 +617,11 @@ class BedrockModel(BaseChatModel):
         https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#message-inference-examples
         """
         messages = []
-        for message in chat_request.messages:
+        # Strip orphan tool_use / tool_result pairs so Bedrock's strict
+        # pairing requirement is satisfied even when the client sends a
+        # rewritten history.
+        sanitized_messages = self._sanitize_tool_pairs(chat_request.messages)
+        for message in sanitized_messages:
             if isinstance(message, UserMessage):
                 messages.append(
                     {

--- a/test/test_parse_messages_sanitize.py
+++ b/test/test_parse_messages_sanitize.py
@@ -1,0 +1,183 @@
+"""Unit tests for BedrockModel._sanitize_tool_pairs / _parse_messages.
+
+Drop-in for upstream PR (aws-samples/bedrock-access-gateway). Place at
+``test/test_parse_messages_sanitize.py`` in the upstream repo and run with::
+
+    pytest test/test_parse_messages_sanitize.py
+
+The tests exercise the strict Bedrock Converse pairing rule: every ``toolUse``
+must be followed by a matching ``toolResult`` block. They assert that the
+sanitiser drops orphan tool_calls / tool_results from the OpenAI message list
+before translation, and that well-formed sequences are unchanged.
+"""
+
+import json
+from typing import Iterable
+
+import pytest
+from api.models.bedrock import BedrockModel
+from api.schema import (
+    AssistantMessage,
+    ChatRequest,
+    ResponseFunction,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+
+
+def _tc(call_id: str, query: str = "x") -> ToolCall:
+    return ToolCall(
+        id=call_id,
+        type="function",
+        function=ResponseFunction(
+            name="kb_lookup",
+            arguments=json.dumps({"query": query}),
+        ),
+    )
+
+
+def _ids(parsed: list, kind: str) -> list[str]:
+    """Collect ``toolUse`` or ``toolResult`` ids from a parsed message list."""
+    out: list[str] = []
+    for msg in parsed:
+        for block in msg.get("content", []):
+            if kind in block:
+                out.append(block[kind]["toolUseId"])
+    return out
+
+
+def _assert_balanced(parsed: list) -> None:
+    use_ids = _ids(parsed, "toolUse")
+    result_ids = _ids(parsed, "toolResult")
+    assert set(use_ids) == set(result_ids), f"Unbalanced tool pairs: toolUse={use_ids} toolResult={result_ids}"
+
+
+@pytest.fixture
+def model() -> BedrockModel:
+    return BedrockModel()
+
+
+@pytest.fixture
+def model_id() -> str:
+    return "anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+
+def test_orphan_tool_calls_are_dropped(model: BedrockModel, model_id: str) -> None:
+    """Assistant ``tool_calls`` without matching ``ToolMessage`` are removed."""
+    request = ChatRequest(
+        model=model_id,
+        messages=[
+            UserMessage(role="user", content="ask"),
+            AssistantMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[_tc("orphan-1"), _tc("orphan-2")],
+            ),
+            UserMessage(role="user", content="continue"),
+        ],
+    )
+
+    parsed = model._parse_messages(request)
+
+    assert _ids(parsed, "toolUse") == []
+    _assert_balanced(parsed)
+
+
+def test_well_formed_sequence_is_unchanged(model: BedrockModel, model_id: str) -> None:
+    """Sanitiser is a no-op when every ``toolUse`` has a matching ``toolResult``."""
+    request = ChatRequest(
+        model=model_id,
+        messages=[
+            UserMessage(role="user", content="ask"),
+            AssistantMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[_tc("ok-1")],
+            ),
+            ToolMessage(role="tool", tool_call_id="ok-1", content="result"),
+            UserMessage(role="user", content="thanks"),
+        ],
+    )
+
+    parsed = model._parse_messages(request)
+
+    assert _ids(parsed, "toolUse") == ["ok-1"]
+    assert _ids(parsed, "toolResult") == ["ok-1"]
+    _assert_balanced(parsed)
+
+
+def test_orphan_tool_result_is_dropped(model: BedrockModel, model_id: str) -> None:
+    """``ToolMessage`` with no matching ``tool_call`` is removed."""
+    request = ChatRequest(
+        model=model_id,
+        messages=[
+            UserMessage(role="user", content="hi"),
+            ToolMessage(
+                role="tool",
+                tool_call_id="orphan-result",
+                content="leftover",
+            ),
+            UserMessage(role="user", content="continue"),
+        ],
+    )
+
+    parsed = model._parse_messages(request)
+
+    assert _ids(parsed, "toolResult") == []
+    _assert_balanced(parsed)
+
+
+def test_partial_pairs_keep_only_paired_ids(model: BedrockModel, model_id: str) -> None:
+    """Orphan tool_calls are dropped; paired ones and the assistant text remain."""
+    request = ChatRequest(
+        model=model_id,
+        messages=[
+            UserMessage(role="user", content="ask"),
+            AssistantMessage(
+                role="assistant",
+                content="Let me check.",
+                tool_calls=[_tc("paired"), _tc("orphan")],
+            ),
+            ToolMessage(role="tool", tool_call_id="paired", content="result"),
+            UserMessage(role="user", content="thanks"),
+        ],
+    )
+
+    parsed = model._parse_messages(request)
+
+    assert _ids(parsed, "toolUse") == ["paired"]
+    assert _ids(parsed, "toolResult") == ["paired"]
+    # Assistant text content survives even though one of its tool_calls was orphaned.
+    assistant_texts: Iterable[str] = (
+        block["text"]
+        for msg in parsed
+        if msg.get("role") == "assistant"
+        for block in msg.get("content", [])
+        if "text" in block
+    )
+    assert "Let me check." in list(assistant_texts)
+    _assert_balanced(parsed)
+
+
+def test_assistant_with_only_orphan_tool_calls_is_dropped(model: BedrockModel, model_id: str) -> None:
+    """An assistant turn that carried only orphaned ``tool_calls`` disappears."""
+    request = ChatRequest(
+        model=model_id,
+        messages=[
+            UserMessage(role="user", content="ask"),
+            AssistantMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[_tc("orphan-only")],
+            ),
+            UserMessage(role="user", content="continue"),
+        ],
+    )
+
+    parsed = model._parse_messages(request)
+
+    # The assistant turn collapses entirely; the two user messages get merged
+    # into a single user turn by ``_reframe_multi_payloard``.
+    assert all(msg["role"] == "user" for msg in parsed)
+    _assert_balanced(parsed)


### PR DESCRIPTION
*Issue #, if available:* _none yet — happy to file one if helpful_

*Description of changes:*

`BedrockModel._parse_messages()` translates the OpenAI message list into Bedrock Converse blocks one entry at a time:

- assistant `tool_calls` → `toolUse` blocks
- `role: tool` messages → `toolResult` blocks

Bedrock's Converse API enforces strict pairing: every `toolUse` must be followed by a matching `toolResult` block. Today the gateway trusts the caller to keep them paired. Real-world clients do not — for example, [Open WebUI](https://github.com/open-webui/open-webui) rewrites the conversation history when the user resumes a chat after a knowledge-base update, dropping `role: tool` messages while keeping the assistant message that produced their `tool_calls`. The next request to `/v1/chat/completions` then arrives at the gateway with an unbalanced sequence and Bedrock rejects it with:

```
ValidationException: messages.N: tool_use ids were found without tool_result blocks
immediately after: <id1>, <id2>. Each tool_use block must have a corresponding
tool_result block in the next message.
```

This PR adds `BedrockModel._sanitize_tool_pairs()`, called once at the top of `_parse_messages()`. It walks the OpenAI message list and:

1. Collects every `tool_call_id` produced by an assistant `tool_calls` entry.
2. Collects every `tool_call_id` consumed by a `ToolMessage`.
3. Keeps only ids present in both sets; drops orphan `tool_calls` from assistant messages and orphan `ToolMessage`s entirely.
4. Preserves assistant text content even when its `tool_calls` were removed; only drops the assistant message when the orphan `tool_calls` were its only payload.

Effects:

- Well-formed sequences are unchanged (sanitiser is a no-op when both sets match).
- Malformed sequences from clients are now translated into a balanced Converse payload that Bedrock accepts.
- Behaviour matches the documented Converse pairing requirement: <https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html>.

A new unit test (`test/test_parse_messages_sanitize.py`) covers five cases against `BedrockModel._parse_messages`:

| Case | Expectation |
|---|---|
| Assistant `tool_calls` with no `ToolMessage` | Orphan `toolUse` blocks dropped |
| All `toolUse` paired with `toolResult` | Output unchanged |
| Stray `ToolMessage` with no matching `tool_call` | Orphan `toolResult` dropped |
| Mixed paired + orphan `tool_calls` on the same assistant | Only the orphaned half is dropped, text content kept |
| Assistant turn carries only orphaned `tool_calls` | Whole turn collapses out of the message list |

Each case asserts the resulting Bedrock message list contains a balanced set of `toolUse`/`toolResult` ids.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
