### PR TITLE
fix(stream): preserve non-negative tool call indexes

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -421,6 +421,8 @@ class BedrockModel(BaseChatModel):
             message_id = self.generate_message_id()
             stream = response.get("stream")
             self.think_emitted = False
+            self._stream_tool_index_by_content_block = {}
+            self._next_stream_tool_index = 0
             reasoning_tokens = 0
             async for chunk in self._async_iterate(stream):
                 # Accumulate reasoning tokens from delta chunks before processing
@@ -457,6 +459,8 @@ class BedrockModel(BaseChatModel):
             # return an [DONE] message at the end.
             yield self.stream_response_to_bytes()
             self.think_emitted = False  # Cleanup
+            self._stream_tool_index_by_content_block = {}
+            self._next_stream_tool_index = 0
         except Exception as e:
             logger.error("Stream error for model %s: %s", chat_request.model, str(e))
             error_event = Error(error=ErrorMessage(message=str(e)))
@@ -1026,8 +1030,13 @@ class BedrockModel(BaseChatModel):
             # tool call start
             delta = chunk["contentBlockStart"]["start"]
             if "toolUse" in delta:
-                # first index is content
-                index = chunk["contentBlockStart"]["contentBlockIndex"] - 1
+                content_block_index = chunk["contentBlockStart"]["contentBlockIndex"]
+                tool_index_map = getattr(self, "_stream_tool_index_by_content_block", {})
+                if content_block_index not in tool_index_map:
+                    tool_index_map[content_block_index] = getattr(self, "_next_stream_tool_index", 0)
+                    self._next_stream_tool_index = tool_index_map[content_block_index] + 1
+                    self._stream_tool_index_by_content_block = tool_index_map
+                index = tool_index_map[content_block_index]
                 message = ChatResponseMessage(
                     tool_calls=[
                         ToolCall(
@@ -1069,7 +1078,13 @@ class BedrockModel(BaseChatModel):
                         return None  # Ignore signature if no <think> started
             else:
                 # tool use
-                index = chunk["contentBlockDelta"]["contentBlockIndex"] - 1
+                content_block_index = chunk["contentBlockDelta"]["contentBlockIndex"]
+                tool_index_map = getattr(self, "_stream_tool_index_by_content_block", {})
+                if content_block_index not in tool_index_map:
+                    tool_index_map[content_block_index] = getattr(self, "_next_stream_tool_index", 0)
+                    self._next_stream_tool_index = tool_index_map[content_block_index] + 1
+                    self._stream_tool_index_by_content_block = tool_index_map
+                index = tool_index_map[content_block_index]
                 message = ChatResponseMessage(
                     tool_calls=[
                         ToolCall(

--- a/tests/test_bedrock_stream_tool_call_index.py
+++ b/tests/test_bedrock_stream_tool_call_index.py
@@ -1,0 +1,90 @@
+import unittest
+
+from api.models.bedrock import BedrockModel
+
+
+class BedrockStreamToolCallIndexTest(unittest.TestCase):
+    def setUp(self):
+        self.model = BedrockModel()
+        self.model.think_emitted = False
+        self.model._stream_tool_index_by_content_block = {}
+        self.model._next_stream_tool_index = 0
+
+    def test_first_streamed_tool_call_uses_non_negative_index(self):
+        start_chunk = {
+            "contentBlockStart": {
+                "contentBlockIndex": 0,
+                "start": {
+                    "toolUse": {
+                        "toolUseId": "tooluse_123",
+                        "name": "get_weather",
+                    }
+                },
+            }
+        }
+        delta_chunk = {
+            "contentBlockDelta": {
+                "contentBlockIndex": 0,
+                "delta": {
+                    "toolUse": {
+                        "input": "{\"city\":\"Boston\"}",
+                    }
+                },
+            }
+        }
+
+        start_response = self.model._create_response_stream(
+            model_id="us.anthropic.claude-sonnet-4-6",
+            message_id="chatcmpl-test",
+            chunk=start_chunk,
+        )
+        delta_response = self.model._create_response_stream(
+            model_id="us.anthropic.claude-sonnet-4-6",
+            message_id="chatcmpl-test",
+            chunk=delta_chunk,
+        )
+
+        self.assertEqual(start_response.choices[0].delta.tool_calls[0].index, 0)
+        self.assertEqual(delta_response.choices[0].delta.tool_calls[0].index, 0)
+
+    def test_multiple_streamed_tool_calls_are_indexed_by_tool_ordinal(self):
+        tool_one_start = {
+            "contentBlockStart": {
+                "contentBlockIndex": 0,
+                "start": {
+                    "toolUse": {
+                        "toolUseId": "tooluse_1",
+                        "name": "get_weather",
+                    }
+                },
+            }
+        }
+        tool_two_start = {
+            "contentBlockStart": {
+                "contentBlockIndex": 2,
+                "start": {
+                    "toolUse": {
+                        "toolUseId": "tooluse_2",
+                        "name": "lookup_news",
+                    }
+                },
+            }
+        }
+
+        tool_one_response = self.model._create_response_stream(
+            model_id="us.anthropic.claude-sonnet-4-6",
+            message_id="chatcmpl-test",
+            chunk=tool_one_start,
+        )
+        tool_two_response = self.model._create_response_stream(
+            model_id="us.anthropic.claude-sonnet-4-6",
+            message_id="chatcmpl-test",
+            chunk=tool_two_start,
+        )
+
+        self.assertEqual(tool_one_response.choices[0].delta.tool_calls[0].index, 0)
+        self.assertEqual(tool_two_response.choices[0].delta.tool_calls[0].index, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix OpenAI-compatible streaming tool-call indexes so they stay non-negative
- map Bedrock `contentBlockIndex` values to zero-based tool-call ordinals instead of subtracting 1
- add a regression test covering the first streamed tool call and multiple tool calls in one stream

## Problem
Streaming tool-call chunks were being emitted with `tool_calls[].index = -1` for the first tool call. Strict OpenAI-compatible clients reject that shape and fail during streamed tool use.

I reproduced this against a live deployment with a request like:

```json
{
  "model": "us.anthropic.claude-sonnet-4-6",
  "stream": true,
  "stream_options": {"include_usage": true},
  "messages": [{"role": "user", "content": "Use a tool call. Return weather for Boston."}],
  "tools": [{
    "type": "function",
    "function": {
      "name": "get_weather",
      "description": "Get weather",
      "parameters": {
        "type": "object",
        "properties": {"city": {"type": "string"}},
        "required": ["city"]
      }
    }
  }]
}
```

Before this patch, the stream contained chunks like:

```json
{"delta":{"tool_calls":[{"index":-1,"id":"tooluse_...","type":"function","function":{"name":"get_weather","arguments":""}}]}}
```

That matches the existing negative-index bug report in #203.

## Fix
The converter was using `contentBlockIndex - 1` as the OpenAI `tool_calls[].index`. That is not safe, because `contentBlockIndex` is a content-block position, not a tool-call ordinal.

This patch keeps a per-stream mapping from Bedrock `contentBlockIndex` to the next zero-based tool-call ordinal and reuses that mapping for later deltas from the same tool call.

## Validation
Ran the focused regression test inside the project runtime image:

```bash
docker run --rm \
  -e PYTHONPATH=/work/src \
  -v /tmp/bedrock-access-gateway-bokmann:/work \
  -w /work \
  --entrypoint python \
  919493069736.dkr.ecr.us-east-1.amazonaws.com/bedrock-proxy-api-fabro@sha256:2ef96c1248daee22db1eee404f3fe15e55d728dc937251730e4b64a1e41f5f4e \
  -m unittest tests.test_bedrock_stream_tool_call_index -v
```

Fixes #203.
