### PR TITLE
feat: Add Claude Opus 4.7 adaptive thinking support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -100,11 +100,22 @@ TEMPERATURE_TOPP_CONFLICT_MODELS = {
     "claude-opus-4-5",
 }
 
+# Models that use adaptive thinking (thinking.type=adaptive + output_config.effort)
+ADAPTIVE_THINKING_MODELS = {
+    "claude-opus-4-7",
+}
+
+# Models that do not support sampling parameters (temperature, topP)
+NO_SAMPLING_PARAMS_MODELS = {
+    "claude-opus-4-7",
+}
+
 # Models that don't support assistant message prefill
 # For these models, if conversation ends with assistant message (e.g., "continue response"),
 # a user message will be added to ask the model to continue
 NO_ASSISTANT_PREFILL_MODELS = {
     "claude-opus-4-6",
+    "claude-opus-4-7",
 }
 
 
@@ -804,6 +815,11 @@ class BedrockModel(BaseChatModel):
                 if DEBUG:
                     logger.info(f"Removed topP for {chat_request.model} (conflicts with temperature)")
 
+        # Strip sampling parameters for models that don't support them
+        if any(m in model_lower for m in NO_SAMPLING_PARAMS_MODELS):
+            inference_config.pop("temperature", None)
+            inference_config.pop("topP", None)
+
         if chat_request.stop is not None:
             stop = chat_request.stop
             if isinstance(stop, str):
@@ -823,7 +839,13 @@ class BedrockModel(BaseChatModel):
             resolved_model = self._resolve_to_foundation_model(chat_request.model)
             model_lower = resolved_model.lower()
 
-            if "anthropic.claude" in model_lower:
+            if any(m in model_lower for m in ADAPTIVE_THINKING_MODELS):
+                # Opus 4.7+: adaptive thinking format
+                args["additionalModelRequestFields"] = {
+                    "thinking": {"type": "adaptive", "display": "summarized"},
+                    "output_config": {"effort": chat_request.reasoning_effort},
+                }
+            elif "anthropic.claude" in model_lower:
                 # Claude format: reasoning_config = object with budget_tokens
                 if effective_max_tokens is None:
                     raise HTTPException(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+"""
+Shared test fixtures and pre-import patches.
+
+boto3 and tiktoken are patched before any test module imports the bedrock module,
+preventing real AWS calls and encoding downloads during test collection.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def _mock_client_factory(service_name, **kwargs):
+    """Factory that returns mock clients for bedrock services."""
+    mock = MagicMock()
+    if service_name == "bedrock":
+        mock.list_foundation_models.return_value = {"modelSummaries": []}
+        paginator_mock = MagicMock()
+        paginator_mock.paginate.return_value = []
+        mock.get_paginator.return_value = paginator_mock
+    return mock
+
+
+# Patch boto3 and tiktoken at module level so they're active before bedrock imports
+_boto3_patch = patch("boto3.client", side_effect=_mock_client_factory)
+_tiktoken_patch = patch(
+    "tiktoken.get_encoding", return_value=MagicMock(encode=lambda x: x.split())
+)
+_boto3_patch.start()
+_tiktoken_patch.start()
+
+
+@pytest.fixture(autouse=True)
+def patch_profile_metadata(monkeypatch):
+    """Populate profile_metadata for cross-region model IDs."""
+    import api.models.bedrock as bedrock_module
+
+    monkeypatch.setattr(bedrock_module, "profile_metadata", {
+        "us.anthropic.claude-opus-4-7": {
+            "underlying_model_id": "anthropic.claude-opus-4-7",
+            "profile_type": "SYSTEM_DEFINED",
+        },
+        "us.anthropic.claude-sonnet-4-5-20250514-v1:0": {
+            "underlying_model_id": "anthropic.claude-sonnet-4-5-20250514-v1:0",
+            "profile_type": "SYSTEM_DEFINED",
+        },
+    })
+    monkeypatch.setattr(bedrock_module, "ENABLE_PROMPT_CACHING", False)

--- a/tests/test_opus47_properties.py
+++ b/tests/test_opus47_properties.py
@@ -1,0 +1,211 @@
+"""
+Tests for Opus 4.7 Adaptive Thinking Support.
+
+Verifies adaptive thinking request format, sampling parameter stripping,
+legacy model compatibility, and assistant prefill handling.
+
+Run with: pytest -v
+"""
+
+import pytest
+
+from api.models.bedrock import BedrockModel
+from api.schema import ChatRequest, UserMessage, AssistantMessage
+
+
+# --- Helpers ---
+
+
+def _make_chat_request(
+    model: str,
+    reasoning_effort=None,
+    temperature=None,
+    top_p=None,
+    max_tokens=2048,
+    messages=None,
+) -> ChatRequest:
+    """Helper to construct a valid ChatRequest for testing."""
+    if messages is None:
+        messages = [UserMessage(content="Hello, world!")]
+    return ChatRequest(
+        model=model,
+        messages=messages,
+        reasoning_effort=reasoning_effort,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+    )
+
+
+def _parse_request(chat_request: ChatRequest) -> dict:
+    """Call _parse_request on a BedrockModel instance."""
+    model = BedrockModel()
+    return model._parse_request(chat_request)
+
+
+# --- Test constants ---
+
+OPUS_47_MODELS = [
+    "us.anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-7",
+]
+
+REASONING_EFFORTS = ["low", "medium", "high"]
+
+LEGACY_CLAUDE_MODELS = [
+    "us.anthropic.claude-sonnet-4-5-20250514-v1:0",
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+]
+
+
+# =============================================================================
+# Adaptive shape correctness
+# For Opus 4.7 + non-null reasoning_effort, additionalModelRequestFields
+# contains exactly `thinking` + `output_config`, never `reasoning_config`/`budget_tokens`.
+# =============================================================================
+
+
+@pytest.mark.parametrize("model_id", OPUS_47_MODELS)
+@pytest.mark.parametrize("effort", REASONING_EFFORTS)
+def test_opus47_has_thinking_and_output_config(model_id, effort):
+    """Opus 4.7 + reasoning_effort produces thinking + output_config, not reasoning_config."""
+    request = _make_chat_request(model=model_id, reasoning_effort=effort)
+    args = _parse_request(request)
+
+    assert "additionalModelRequestFields" in args, (
+        f"Expected additionalModelRequestFields for model={model_id}, effort={effort}"
+    )
+
+    additional = args["additionalModelRequestFields"]
+
+    assert additional == {
+        "thinking": {"type": "adaptive", "display": "summarized"},
+        "output_config": {"effort": effort},
+    }, f"Unexpected additionalModelRequestFields shape: {additional}"
+
+    assert "reasoning_config" not in additional
+    assert "budget_tokens" not in str(additional)
+
+
+# =============================================================================
+# Sampling parameter stripping
+# For Opus 4.7, inferenceConfig never contains temperature/topP regardless
+# of what the client sends. maxTokens IS preserved.
+# =============================================================================
+
+
+@pytest.mark.parametrize("model_id", OPUS_47_MODELS)
+@pytest.mark.parametrize("temperature,top_p", [
+    (0.7, 0.9),
+    (0.0, 1.0),
+    (2.0, 0.5),
+    (1.0, None),
+    (None, 0.8),
+])
+def test_opus47_strips_temperature_and_top_p(model_id, temperature, top_p):
+    """Opus 4.7 strips temperature/topP but preserves maxTokens."""
+    max_tokens = 4096
+    request = _make_chat_request(
+        model=model_id,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+    )
+    args = _parse_request(request)
+
+    inference_config = args["inferenceConfig"]
+
+    assert "temperature" not in inference_config, (
+        f"temperature should be stripped for Opus 4.7, got: {inference_config}"
+    )
+    assert "topP" not in inference_config, (
+        f"topP should be stripped for Opus 4.7, got: {inference_config}"
+    )
+    assert "maxTokens" in inference_config
+    assert inference_config["maxTokens"] == max_tokens
+
+
+# =============================================================================
+# Legacy model compatibility
+# Non-Opus-4.7 Claude + reasoning_effort produces reasoning_config with budget_tokens.
+# =============================================================================
+
+
+@pytest.mark.parametrize("model_id", LEGACY_CLAUDE_MODELS)
+@pytest.mark.parametrize("effort", REASONING_EFFORTS)
+def test_legacy_claude_uses_reasoning_config(model_id, effort):
+    """Legacy Claude + reasoning_effort produces reasoning_config with budget_tokens."""
+    request = _make_chat_request(model=model_id, reasoning_effort=effort)
+    args = _parse_request(request)
+
+    assert "additionalModelRequestFields" in args, (
+        f"Expected additionalModelRequestFields for legacy model={model_id}"
+    )
+
+    additional = args["additionalModelRequestFields"]
+
+    assert "reasoning_config" in additional, (
+        f"Expected 'reasoning_config' for legacy Claude, got: {additional}"
+    )
+    reasoning_config = additional["reasoning_config"]
+    assert reasoning_config["type"] == "enabled"
+    assert "budget_tokens" in reasoning_config
+    assert isinstance(reasoning_config["budget_tokens"], int)
+    assert reasoning_config["budget_tokens"] > 0
+
+    assert "thinking" not in additional
+    assert "output_config" not in additional
+
+
+# =============================================================================
+# Assistant prefill handling
+# Opus 4.7 conversations ending with assistant role get a user message appended.
+# When conversation ends with user message, no extra message is appended.
+# =============================================================================
+
+
+@pytest.mark.parametrize("model_id", OPUS_47_MODELS)
+@pytest.mark.parametrize("assistant_text", [
+    "Sure, let me help.",
+    "Here is the code:",
+    "I'll continue from where I left off.",
+])
+def test_opus47_assistant_ending_gets_user_appended(model_id, assistant_text):
+    """Conversations ending with assistant message get a continuation user message appended."""
+    messages = [
+        UserMessage(content="Hello"),
+        AssistantMessage(content=assistant_text),
+    ]
+    request = _make_chat_request(model=model_id, messages=messages)
+    args = _parse_request(request)
+
+    result_messages = args["messages"]
+
+    assert result_messages[-1]["role"] == "user", (
+        f"Expected last message role='user', got: {result_messages[-1]['role']}"
+    )
+    last_content = result_messages[-1]["content"]
+    assert any("text" in item for item in last_content), (
+        f"Expected text content in continuation message, got: {last_content}"
+    )
+
+
+@pytest.mark.parametrize("model_id", OPUS_47_MODELS)
+@pytest.mark.parametrize("user_text", [
+    "Hello, world!",
+    "What is the meaning of life?",
+    "Please write some code.",
+])
+def test_opus47_user_ending_no_extra_message(model_id, user_text):
+    """Conversations ending with user message are not modified."""
+    messages = [UserMessage(content=user_text)]
+    request = _make_chat_request(model=model_id, messages=messages)
+    args = _parse_request(request)
+
+    result_messages = args["messages"]
+
+    user_messages = [m for m in result_messages if m["role"] == "user"]
+    assert len(user_messages) == 1, (
+        f"Expected exactly 1 user message, got {len(user_messages)}: {result_messages}"
+    )
+    assert result_messages[-1]["role"] == "user"


### PR DESCRIPTION
*Issue #, if available:*

#248 

Description of changes:

Adds support for Claude Opus 4.7's adaptive thinking API format, which differs from earlier Claude models in three ways (see linked issue for reproduction steps with exact error responses).

**Key changes in `src/api/models/bedrock.py`:**

- `ADAPTIVE_THINKING_MODELS` — New model set for Opus 4.7+. When `reasoning_effort` is requested, sends `thinking.type=adaptive` + `output_config.effort` via `additionalModelRequestFields` instead of `reasoning_config.budget_tokens`.
- `NO_SAMPLING_PARAMS_MODELS` — Strips `temperature`/`topP` from `inferenceConfig` for models that reject sampling parameters.
- `NO_ASSISTANT_PREFILL_MODELS` — Added Opus 4.7 (like Opus 4.6, it doesn't support assistant message prefill).

All changes are additive and backward-compatible — existing models are unaffected.

**Tests (optional, can be omitted):**

This PR includes `tests/conftest.py` and `tests/test_opus47_properties.py` covering the following scenarios:

- **Adaptive thinking shape** — for all `reasoning_effort` values (`low`/`medium`/`high`) on `us.anthropic.claude-opus-4-7` (cross-region inference profile), verifies `additionalModelRequestFields` contains `thinking.type=adaptive` + `output_config.effort`, and that `reasoning_config`/`budget_tokens` are absent.
- **Sampling parameter stripping** — verifies `temperature` and `topP` are removed from `inferenceConfig` across a range of input combinations, while `maxTokens` is preserved.
- **Legacy model compatibility** — verifies existing Claude models (e.g. Sonnet 4.5) still produce the `reasoning_config.budget_tokens` format unchanged.
- **Assistant prefill handling** — verifies conversations ending with an assistant message get a continuation user message appended, and user-ending conversations are unmodified.

Since the upstream repo does not currently have a test suite, maintainers may choose to exclude these files if they prefer to keep the test infrastructure decision separate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.