### PR TITLE
feat: forward user info headers as Bedrock requestMetadata

### DIFF
--- a/src/api/models/base.py
+++ b/src/api/models/base.py
@@ -33,12 +33,12 @@ class BaseChatModel(ABC):
         pass
 
     @abstractmethod
-    async def chat(self, chat_request: ChatRequest) -> ChatResponse:
+    async def chat(self, chat_request: ChatRequest, request_metadata: dict | None = None) -> ChatResponse:
         """Handle a basic chat completion requests."""
         pass
 
     @abstractmethod
-    async def chat_stream(self, chat_request: ChatRequest) -> AsyncIterable[bytes]:
+    async def chat_stream(self, chat_request: ChatRequest, request_metadata: dict | None = None) -> AsyncIterable[bytes]:
         """Handle a basic chat completion requests with stream response."""
         pass
 

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -332,7 +332,7 @@ class BedrockModel(BaseChatModel):
 
         return None
 
-    async def _invoke_bedrock(self, chat_request: ChatRequest, stream=False):
+    async def _invoke_bedrock(self, chat_request: ChatRequest, stream=False, request_metadata: dict | None = None):
         """Common logic for invoke bedrock models"""
         if DEBUG:
             logger.info("Raw request: " + chat_request.model_dump_json())
@@ -347,6 +347,11 @@ class BedrockModel(BaseChatModel):
 
         # convert OpenAI chat request to Bedrock SDK request
         args = self._parse_request(chat_request)
+
+        # Attach request metadata for cost attribution (appears in model invocation logs)
+        if request_metadata:
+            args["requestMetadata"] = request_metadata
+
         if DEBUG:
             logger.info("Bedrock request: " + json.dumps(str(args)))
 
@@ -370,11 +375,11 @@ class BedrockModel(BaseChatModel):
             raise HTTPException(status_code=500, detail=str(e))
         return response
 
-    async def chat(self, chat_request: ChatRequest) -> ChatResponse:
+    async def chat(self, chat_request: ChatRequest, request_metadata: dict | None = None) -> ChatResponse:
         """Default implementation for Chat API."""
 
         message_id = self.generate_message_id()
-        response = await self._invoke_bedrock(chat_request)
+        response = await self._invoke_bedrock(chat_request, request_metadata=request_metadata)
 
         output_message = response["output"]["message"]
         usage = response["usage"]
@@ -414,10 +419,10 @@ class BedrockModel(BaseChatModel):
             await run_in_threadpool(lambda: chunk)
             yield chunk
 
-    async def chat_stream(self, chat_request: ChatRequest) -> AsyncIterable[bytes]:
+    async def chat_stream(self, chat_request: ChatRequest, request_metadata: dict | None = None) -> AsyncIterable[bytes]:
         """Default implementation for Chat Stream API"""
         try:
-            response = await self._invoke_bedrock(chat_request, stream=True)
+            response = await self._invoke_bedrock(chat_request, stream=True, request_metadata=request_metadata)
             message_id = self.generate_message_id()
             stream = response.get("stream")
             self.think_emitted = False

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -1,24 +1,41 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import StreamingResponse
 
 from api.auth import api_key_auth
 from api.models.bedrock import BedrockModel
 from api.schema import ChatRequest, ChatResponse, ChatStreamResponse, Error
-from api.setting import DEFAULT_MODEL
+from api.setting import DEFAULT_MODEL, ENABLE_REQUEST_METADATA
 
 router = APIRouter(
     prefix="/chat",
     dependencies=[Depends(api_key_auth)],
-    # responses={404: {"description": "Not found"}},
 )
+
+# Headers forwarded by OpenWebUI when ENABLE_FORWARD_USER_INFO_HEADERS=true
+_USER_INFO_HEADERS = [
+    ("x-openwebui-user-name", "user"),
+    ("x-openwebui-user-id", "user_id"),
+    ("x-openwebui-user-email", "user_email"),
+    ("x-openwebui-user-role", "user_role"),
+]
+
+
+def _extract_request_metadata(request: Request) -> dict[str, str]:
+    """Extract user info headers into a Bedrock requestMetadata dict."""
+    metadata = {}
+    for header, key in _USER_INFO_HEADERS:
+        if val := request.headers.get(header):
+            metadata[key] = val[:256]  # Bedrock enforces 256 char limit per value
+    return metadata
 
 
 @router.post(
     "/completions", response_model=ChatResponse | ChatStreamResponse | Error, response_model_exclude_unset=True
 )
 async def chat_completions(
+    request: Request,
     chat_request: Annotated[
         ChatRequest,
         Body(
@@ -37,9 +54,15 @@ async def chat_completions(
     if chat_request.model.lower().startswith("gpt-"):
         chat_request.model = DEFAULT_MODEL
 
+    # Extract request metadata from forwarded user info headers
+    request_metadata = _extract_request_metadata(request) if ENABLE_REQUEST_METADATA else {}
+
     # Exception will be raised if model not supported.
     model = BedrockModel()
     model.validate(chat_request)
     if chat_request.stream:
-        return StreamingResponse(content=model.chat_stream(chat_request), media_type="text/event-stream")
-    return await model.chat(chat_request)
+        return StreamingResponse(
+            content=model.chat_stream(chat_request, request_metadata=request_metadata),
+            media_type="text/event-stream",
+        )
+    return await model.chat(chat_request, request_metadata=request_metadata)

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -16,3 +16,4 @@ DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embe
 ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
 ENABLE_APPLICATION_INFERENCE_PROFILES = os.environ.get("ENABLE_APPLICATION_INFERENCE_PROFILES", "true").lower() != "false"
 ENABLE_PROMPT_CACHING = os.environ.get("ENABLE_PROMPT_CACHING", "false").lower() != "false"
+ENABLE_REQUEST_METADATA = os.environ.get("ENABLE_REQUEST_METADATA", "true").lower() != "false"


### PR DESCRIPTION
## Summary

When `ENABLE_REQUEST_METADATA=true` (default), the gateway extracts `X-OpenWebUI-User-*` headers from incoming chat completion requests and passes them as `requestMetadata` to the Bedrock Converse/ConverseStream API calls.

This enables per-user and per-team cost attribution via [model invocation logs](https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html).

## Motivation

When using the gateway behind OpenWebUI (or any proxy that forwards user identity headers), there's currently no way to attribute Bedrock API costs to individual users. The Bedrock Converse API supports a `requestMetadata` parameter that appears in model invocation logs, enabling cost analysis per user/team via CloudWatch Logs Insights or Athena.

OpenWebUI has a built-in `ENABLE_FORWARD_USER_INFO_HEADERS=true` setting that forwards user identity as HTTP headers to OpenAI-compatible backends.

## Changes

- **`src/api/setting.py`**: Added `ENABLE_REQUEST_METADATA` env var (default: `true`)
- **`src/api/routers/chat.py`**: Extract `X-OpenWebUI-User-*` headers into a metadata dict
- **`src/api/models/base.py`**: Updated abstract method signatures to accept `request_metadata`
- **`src/api/models/bedrock.py`**: Pass `requestMetadata` to `converse`/`converse_stream` calls

## Headers mapped

| HTTP Header | requestMetadata key |
|---|---|
| `X-OpenWebUI-User-Name` | `user` |
| `X-OpenWebUI-User-Id` | `user_id` |
| `X-OpenWebUI-User-Email` | `user_email` |
| `X-OpenWebUI-User-Role` | `user_role` |

## Usage

1. Set `ENABLE_FORWARD_USER_INFO_HEADERS=true` on your OpenWebUI instance
2. The gateway automatically forwards user metadata to Bedrock (enabled by default)
3. Enable [model invocation logging](https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html) in your AWS account
4. Query logs with CloudWatch Logs Insights:
   ```sql
   filter requestMetadata.user = "john.doe"
   | stats sum(inputTokenCount) as input_tokens, sum(outputTokenCount) as output_tokens by requestMetadata.user
   ```

## Testing

- Python syntax verified for all modified files
- No breaking changes — `request_metadata` parameter is optional with default `None`
- Feature is gated behind `ENABLE_REQUEST_METADATA` env var (can be disabled)
