### PR TITLE
chore: bump dependencies

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,10 +1,10 @@
-fastapi==0.128.0
-starlette==0.49.1  # CVE-2025-62727: Fix ReDoS in Range header parsing
-pydantic==2.11.4
-uvicorn==0.29.0
-mangum==0.17.0
-tiktoken==0.9.0
-requests==2.33.0
-numpy==2.2.5
-boto3==1.40.4
-botocore==1.40.4
+fastapi==0.136.3
+starlette==1.1.0
+pydantic==2.13.4
+uvicorn==0.48.0
+mangum==0.21.0
+tiktoken==0.13.0
+requests==2.34.2
+numpy==2.4.6
+boto3==1.43.15
+botocore==1.43.15


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
bump dependencies including updating starlette for CVE-2026-48710

**contains breaking change in FastAPI 0.132.0 "Add strict_content_type checking for JSON requests"**
https://fastapi.tiangolo.com/release-notes/#01320-2026-02-23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
