### PR TITLE
feat(audit): per-tool-call WORM audit-record emitter, dark (TPAI m1 Phase B(ii), R10/R11)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: pytest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: src/requirements-dev.txt
+
+      - name: Install dependencies
+        working-directory: src
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        working-directory: src
+        run: python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,9 @@ cython_debug/
 
 Config
 .vscode/launch.json
+
+# macOS
+.DS_Store
+
+# Deployment artifacts (environment-specific)
+src/task-definition.json

--- a/docs/AuditRecords.md
+++ b/docs/AuditRecords.md
@@ -1,0 +1,70 @@
+# Tool-Call Audit Records (WORM sink)
+
+Part of the TPAI external-content program, m1 Phase B(ii)
+(`plans/external-content/m1-substrate/plan.md` in the main repo). Schema
+ratified 2026-07-02 (program decisions **R10** — 7-year WORM retention —
+and **R11** — field set incl. full URL, latency, policy-decision reason).
+
+Every server-side tool execution the gateway performs (`web_fetch` from m2,
+`gmail_*` from m3) writes exactly one JSON record to an S3 bucket with
+Object Lock in **COMPLIANCE mode, 7-year retention**, stood up by the main
+repo's `audit-sink-stack` (Product account). The Phase E connector writes a
+matching record on its side of the PrivateLink boundary; the pair answers
+*"who fetched what, when, and why was it allowed."*
+
+Emitter: [`src/api/audit.py`](../src/api/audit.py) ·
+Tests: [`src/tests/test_audit.py`](../src/tests/test_audit.py)
+
+## Schema — `tpai.gateway.tool-call.v1`
+
+One JSON object per record, sorted keys, compact separators. Every field is
+always present (nullable fields serialize as `null`, never omitted).
+
+| Field | Type | Semantics |
+|---|---|---|
+| `schema` | string | Constant `tpai.gateway.tool-call.v1`. Bump the suffix on any field change — 7-year-old records must stay parseable. |
+| `ts` | string | ISO-8601 UTC, millisecond precision (e.g. `2026-07-02T15:04:05.123+00:00`). Emission time = tool-call completion. |
+| `identity` | string | Pseudonymous HMAC identity from `api/identity.py` (dedicated Product-account key, decision E2). Required — tool execution is only reachable behind `require_identity`. Never the raw email. |
+| `tool` | string | Tool name, e.g. `web_fetch`, `gmail_search`, `gmail_get_message`. |
+| `target` | string | **The full URL** (web tools — R11 requires full URL, not just host) or the **message id** (gmail tools). |
+| `policy_decision` | string | `allow` \| `deny` — what the URL/tool policy layer decided. |
+| `policy_reason` | string | Why, e.g. `beta-allow-all`, `allowlist-hit`, `allowlist-miss`, `taint-blocked`, `budget-exhausted` (R11: the allowlist/policy-decision reason is part of the record). |
+| `outcome` | string | `success` \| `denied` \| `error` \| `timeout` — how the call actually ended. A `deny` decision pairs with outcome `denied`. |
+| `bytes` | int \| null | Content bytes returned to the model. `null` when nothing was returned (denied/error paths). |
+| `latency_ms` | int | Wall-clock duration of the tool execution. |
+| `conversation_id` | string \| null | `X-OpenWebUI-Chat-Id` when present (arrives with the m1 Phase D cherry-pick). `null` for background generations and api-proxy callers — those use the session-keyed taint fallback (D9). |
+
+Example:
+
+```json
+{"bytes":20480,"conversation_id":"chat-1234","identity":"9f2c…","latency_ms":812,"outcome":"success","policy_decision":"allow","policy_reason":"beta-allow-all","schema":"tpai.gateway.tool-call.v1","target":"https://example.com/reports/q3","tool":"web_fetch","ts":"2026-07-02T15:04:05.123+00:00"}
+```
+
+## Storage layout
+
+```
+s3://tpai-audit-<env>-<account>/
+  gateway/YYYY/MM/DD/<YYYYMMDDTHHMMSS>-<uuid>.json   ← this emitter
+  connector/…                                        ← Phase E connector records
+```
+
+Date-partitioned for review tooling (Athena/S3 Select); the uuid suffix
+makes concurrent writers collision-free. Object Lock retention is the
+bucket default — the emitter never calls `PutObjectRetention` and the task
+role is not granted it.
+
+## Operating contract
+
+- **Fail closed.** `emit_audit_record` raises `AuditEmitError` on any
+  write failure *including an unconfigured bucket*. Tool executors must
+  fail the tool call — a retrieval that cannot be audited must not happen
+  (ADR-1: "every retrieval is logged"). No fire-and-forget, no
+  buffer-and-drop.
+- **Records never touch logs.** Full URLs and identities exist only in the
+  WORM trail; CloudWatch keeps the metadata-only access line (E3, which
+  carries the tool *name* only). Failure logs carry the exception class
+  and S3 key, never record fields — `test_audit.py` asserts this.
+- **Configuration:** `TPAI_AUDIT_BUCKET` (injected by the CDK wiring),
+  `TPAI_AUDIT_PREFIX` (default `gateway/`).
+- **Dark today:** no server-side tool executes until m2 Phase 0 ships and
+  its flag family is enabled; this module has no production call sites yet.

--- a/docs/AuditRecords.md
+++ b/docs/AuditRecords.md
@@ -51,7 +51,9 @@ s3://tpai-audit-<env>-<account>/
 Date-partitioned for review tooling (Athena/S3 Select); the uuid suffix
 makes concurrent writers collision-free. Object Lock retention is the
 bucket default — the emitter never calls `PutObjectRetention` and the task
-role is not granted it.
+role is not granted it. Puts carry an explicit `ChecksumAlgorithm=CRC32`
+(Object Lock requires a checksum header; do not rely on the botocore
+default).
 
 ## Operating contract
 
@@ -64,7 +66,17 @@ role is not granted it.
   WORM trail; CloudWatch keeps the metadata-only access line (E3, which
   carries the tool *name* only). Failure logs carry the exception class
   and S3 key, never record fields — `test_audit.py` asserts this.
-- **Configuration:** `TPAI_AUDIT_BUCKET` (injected by the CDK wiring),
-  `TPAI_AUDIT_PREFIX` (default `gateway/`).
+- **Configuration:** `TPAI_AUDIT_BUCKET` only (injected by the CDK wiring).
+  The `gateway/` prefix is a code constant, deliberately not configurable:
+  the task role's IAM grant is pinned to exactly `gateway/*`, so any other
+  prefix is an AccessDenied outage. Bounded latency: the S3 client is
+  capped at 2 attempts × (3s connect + 5s read) — worst case ~17s before
+  the tool call fails closed.
+- **m2 wiring requirement:** route every tool execution through a single
+  audited choke point that emits on *all* branches — success, denied,
+  error, and timeout. Per-branch emit calls scattered through the executor
+  is how a branch gets missed and a retrieval happens unaudited; the m3 G4
+  audit-pair review assumes gateway/connector records exist for every
+  fetch.
 - **Dark today:** no server-side tool executes until m2 Phase 0 ships and
   its flag family is enabled; this module has no production call sites yet.

--- a/src/Dockerfile_ecs
+++ b/src/Dockerfile_ecs
@@ -6,6 +6,9 @@ COPY ./requirements.txt /app/requirements.txt
 
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
+# Install curl for reliable health checks (removes Python interpreter startup overhead)
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 COPY ./api /app/api
 
 ENV PORT=80

--- a/src/Dockerfile_ecs
+++ b/src/Dockerfile_ecs
@@ -6,11 +6,14 @@ COPY ./requirements.txt /app/requirements.txt
 
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
-# Install curl for reliable health checks (removes Python interpreter startup overhead)
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+# curl: reliable health checks without Python interpreter startup overhead
+# openssl: startup self-signed certificate for the TLS listener (TPAI HIPAA M1.2)
+RUN apt-get update && apt-get install -y curl openssl && rm -rf /var/lib/apt/lists/*
 
 COPY ./api /app/api
+COPY ./entrypoint_tls.sh /app/entrypoint_tls.sh
+RUN chmod +x /app/entrypoint_tls.sh
 
-ENV PORT=80
+ENV PORT=443
 
-CMD ["sh", "-c", "uvicorn api.app:app --host 0.0.0.0 --port ${PORT}"]
+CMD ["/app/entrypoint_tls.sh"]

--- a/src/api/access_log.py
+++ b/src/api/access_log.py
@@ -1,0 +1,56 @@
+"""Always-on, metadata-only structured access log (TPAI external-content
+program, m1 Phase B(i) / decision E3).
+
+Replaces the deleted DIAG-tagged content-dump lines. Exactly one JSON line
+is emitted per chat completion: status, latency, token counts, tool name,
+outcome, and the pseudonymous HMAC identity (``request.state.tpai_identity``)
+— never message content, never headers, never the raw email.
+
+There is deliberately no debug flag and no break-glass: production
+content-debugging moves to test accounts. The Phase F acceptance check
+asserts that no content fields exist in gateway logs; nothing interpolating
+request or response data may be added here.
+"""
+
+import json
+import logging
+
+logger = logging.getLogger("tpai.access")
+
+
+def emit_chat_access_log(
+    *,
+    identity: str | None,
+    model: str,
+    stream: bool,
+    status: int,
+    latency_ms: int,
+    prompt_tokens: int | None,
+    completion_tokens: int | None,
+    outcome: str,
+    tool: str | None = None,
+) -> None:
+    """Emit the per-request metadata line.
+
+    ``tool`` is always ``None`` today — server-side tool execution arrives
+    with the m1 Phase D taint rule and the m2 ``web_fetch`` tool; the field
+    exists so the schema does not change when it does.
+    """
+    logger.info(
+        json.dumps(
+            {
+                "event": "chat_completion",
+                "identity": identity,
+                "model": model,
+                "stream": stream,
+                "status": status,
+                "latency_ms": latency_ms,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "tool": tool,
+                "outcome": outcome,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )

--- a/src/api/access_log.py
+++ b/src/api/access_log.py
@@ -2,9 +2,21 @@
 program, m1 Phase B(i) / decision E3).
 
 Replaces the deleted DIAG-tagged content-dump lines. Exactly one JSON line
-is emitted per chat completion: status, latency, token counts, tool name,
-outcome, and the pseudonymous HMAC identity (``request.state.tpai_identity``)
-— never message content, never headers, never the raw email.
+is emitted per request that reaches a completion/embeddings handler: status,
+latency, token counts, tool name, outcome, and the pseudonymous HMAC
+identity (``request.state.tpai_identity``) — never message content, never
+headers, never the raw email.
+
+Scope and semantics:
+
+- Requests rejected before the handler runs (401/400 from ``api_key_auth``,
+  ``require_identity``, or FastAPI request validation) produce no line —
+  there is no completion to describe; uvicorn's access log still records
+  method/path/status for them.
+- Streaming responses have already sent wire status 200 when a failure
+  occurs, so ``status`` stays 200 and the failure surfaces in ``outcome``
+  (``error``, or ``aborted`` when the client disconnected mid-stream).
+  Consumers computing error rates must key on ``outcome``, not ``status``.
 
 There is deliberately no debug flag and no break-glass: production
 content-debugging moves to test accounts. The Phase F acceptance check
@@ -18,11 +30,12 @@ import logging
 logger = logging.getLogger("tpai.access")
 
 
-def emit_chat_access_log(
+def emit_access_log(
     *,
+    event: str,
     identity: str | None,
     model: str,
-    stream: bool,
+    stream: bool | None,
     status: int,
     latency_ms: int,
     prompt_tokens: int | None,
@@ -32,14 +45,16 @@ def emit_chat_access_log(
 ) -> None:
     """Emit the per-request metadata line.
 
-    ``tool`` is always ``None`` today — server-side tool execution arrives
-    with the m1 Phase D taint rule and the m2 ``web_fetch`` tool; the field
-    exists so the schema does not change when it does.
+    ``event`` is ``chat_completion`` or ``embeddings`` (``stream`` is None
+    for the latter — not applicable). ``tool`` is always ``None`` today —
+    server-side tool execution arrives with the m1 Phase D taint rule and
+    the m2 ``web_fetch`` tool; the field exists so the schema does not
+    change when it does.
     """
     logger.info(
         json.dumps(
             {
-                "event": "chat_completion",
+                "event": event,
                 "identity": identity,
                 "model": model,
                 "stream": stream,

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -21,7 +21,13 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
+
+logger = logging.getLogger(__name__)
+logger.info("Starting Bedrock Gateway application...")
+
 app = FastAPI(**config)
+
+logger.info("FastAPI application initialized successfully")
 
 app.add_middleware(
     CORSMiddleware,
@@ -36,6 +42,10 @@ app.include_router(model.router, prefix=API_ROUTE_PREFIX)
 app.include_router(chat.router, prefix=API_ROUTE_PREFIX)
 app.include_router(embeddings.router, prefix=API_ROUTE_PREFIX)
 
+
+@app.on_event("startup")
+async def startup_event():
+    logger.info("Application startup complete - ready to serve requests")
 
 @app.get("/health")
 async def health():
@@ -61,4 +71,5 @@ async def validation_exception_handler(request, exc):
 handler = Mangum(app)
 
 if __name__ == "__main__":
+    logger.info("Starting uvicorn server on 0.0.0.0:8000...")
     uvicorn.run("app:app", host="0.0.0.0", port=8000, reload=True)

--- a/src/api/audit.py
+++ b/src/api/audit.py
@@ -1,0 +1,162 @@
+"""Per-tool-call WORM audit records (TPAI external-content program,
+m1 Phase B(ii); decisions R10/R11).
+
+Every server-side tool execution (web_fetch in m2, gmail_* in m3) produces
+exactly one audit record answering "who fetched what, when, and why was it
+allowed". Records are written as individual JSON objects to an S3 bucket
+with Object Lock in COMPLIANCE mode (7-year retention, R10) — the bucket is
+stood up by the main repo's audit-sink stack; this module only writes.
+
+Schema v1 (ratified R11 — full documentation in ``docs/AuditRecords.md``):
+
+    schema           "tpai.gateway.tool-call.v1"
+    ts               ISO-8601 UTC, millisecond precision
+    identity         pseudonymous HMAC identity (api.identity) — required
+    tool             tool name, e.g. "web_fetch", "gmail_search"
+    target           the full URL (web tools) or message id (gmail tools)
+    policy_decision  "allow" | "deny"
+    policy_reason    why, e.g. "beta-allow-all", "budget-exhausted"
+    outcome          "success" | "denied" | "error" | "timeout"
+    bytes            content bytes returned to the model, None if none
+    latency_ms       wall-clock duration of the tool execution
+    conversation_id  X-OpenWebUI-Chat-Id when present, else None
+
+Operating contract:
+
+- **Fail closed.** ``emit_audit_record`` raises ``AuditEmitError`` on any
+  failure, including an unconfigured bucket. Tool executors must treat that
+  as a failed tool call — a retrieval that cannot be audited must not
+  happen (ADR-1: "every retrieval is logged"). There is no fire-and-forget
+  mode and no buffer-and-drop fallback.
+- **The record goes to S3, never to logs.** Full URLs belong in the WORM
+  trail, not in CloudWatch where operators read (the E3 metadata line
+  deliberately carries the tool name only). On failure this module logs the
+  exception class and the S3 key — never any record field.
+- **Synchronous.** boto3 is blocking; async callers (the Converse tool
+  loop) must wrap calls in ``starlette.concurrency.run_in_threadpool`` the
+  same way ``models/bedrock.py`` wraps Bedrock calls.
+
+This path is dark today: the bucket wiring ships with m1 Phase B(ii) but no
+server-side tool executes until m2 Phase 0 lands and its flag is enabled.
+"""
+
+import datetime
+import json
+import logging
+import os
+import threading
+import uuid
+
+import boto3
+from botocore.config import Config
+
+logger = logging.getLogger(__name__)
+
+# Injected by the audit-sink CDK wiring (bedrock-gateway-stack). Unset means
+# this deployment cannot audit — emit_audit_record refuses rather than drops.
+AUDIT_BUCKET = os.environ.get("TPAI_AUDIT_BUCKET", "")
+# Key prefix for gateway-side records; the Phase E connector writes its
+# matching records under connector/ in the same bucket.
+AUDIT_PREFIX = os.environ.get("TPAI_AUDIT_PREFIX", "gateway/")
+
+SCHEMA = "tpai.gateway.tool-call.v1"
+
+VALID_POLICY_DECISIONS = ("allow", "deny")
+VALID_OUTCOMES = ("success", "denied", "error", "timeout")
+
+# The audit put sits on the tool-call critical path (fail closed), so keep
+# its worst case bounded: tight timeouts, standard retries — unlike the
+# long-lived streaming config used for Bedrock calls.
+_S3_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=10,
+    retries={"max_attempts": 3, "mode": "standard"},
+)
+
+_s3_lock = threading.Lock()
+_s3_client = None
+
+
+class AuditEmitError(RuntimeError):
+    """The audit record could not be durably written. Callers must fail the
+    tool call — never execute-and-drop."""
+
+
+def _s3():
+    """Lazy singleton S3 client (unlike bedrock.py's import-time clients, so
+    importing the app never resolves AWS credentials for a dark code path)."""
+    global _s3_client
+    with _s3_lock:
+        if _s3_client is None:
+            _s3_client = boto3.client(
+                "s3",
+                region_name=os.environ.get("AWS_REGION"),
+                config=_S3_CONFIG,
+            )
+        return _s3_client
+
+
+def emit_audit_record(
+    *,
+    identity: str,
+    tool: str,
+    target: str,
+    policy_decision: str,
+    policy_reason: str,
+    outcome: str,
+    bytes_returned: int | None,
+    latency_ms: int,
+    conversation_id: str | None,
+) -> str:
+    """Write one tool-call audit record to the WORM sink; return its S3 key.
+
+    Raises ``AuditEmitError`` if the record cannot be durably written (S3
+    failure or no bucket configured) and ``ValueError`` for records that
+    violate the schema — both mean the tool call must fail.
+    """
+    if not identity:
+        # Tool execution is only reachable behind require_identity; a record
+        # without an accountable identity is a bug, not a degraded mode.
+        raise ValueError("audit record requires a non-empty HMAC identity")
+    if not tool or not target:
+        raise ValueError("audit record requires non-empty tool and target")
+    if policy_decision not in VALID_POLICY_DECISIONS:
+        raise ValueError(f"policy_decision must be one of {VALID_POLICY_DECISIONS}")
+    if outcome not in VALID_OUTCOMES:
+        raise ValueError(f"outcome must be one of {VALID_OUTCOMES}")
+    if not AUDIT_BUCKET:
+        raise AuditEmitError("TPAI_AUDIT_BUCKET is not configured - refusing to execute an unauditable tool call")
+
+    ts = datetime.datetime.now(datetime.timezone.utc)
+    record = {
+        "schema": SCHEMA,
+        "ts": ts.isoformat(timespec="milliseconds"),
+        "identity": identity,
+        "tool": tool,
+        "target": target,
+        "policy_decision": policy_decision,
+        "policy_reason": policy_reason,
+        "outcome": outcome,
+        "bytes": bytes_returned,
+        "latency_ms": latency_ms,
+        "conversation_id": conversation_id,
+    }
+    # Date-partitioned key so 7 years of records stay listable/queryable;
+    # uuid suffix makes concurrent writers collision-free. Object Lock
+    # COMPLIANCE retention is the bucket default — no per-object retention
+    # call (and the task role has no s3:PutObjectRetention to change it).
+    key = f"{AUDIT_PREFIX}{ts:%Y/%m/%d}/{ts:%Y%m%dT%H%M%S}-{uuid.uuid4().hex}.json"
+    body = json.dumps(record, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    try:
+        _s3().put_object(
+            Bucket=AUDIT_BUCKET,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+        )
+    except Exception as exc:
+        # Never log record fields here: the full URL belongs only in the
+        # WORM trail (E3 keeps CloudWatch metadata-only).
+        logger.error("audit record write failed (%s): %s", type(exc).__name__, key)
+        raise AuditEmitError(f"failed to write audit record {key}") from exc
+    return key

--- a/src/api/audit.py
+++ b/src/api/audit.py
@@ -55,22 +55,26 @@ logger = logging.getLogger(__name__)
 # Injected by the audit-sink CDK wiring (bedrock-gateway-stack). Unset means
 # this deployment cannot audit — emit_audit_record refuses rather than drops.
 AUDIT_BUCKET = os.environ.get("TPAI_AUDIT_BUCKET", "")
-# Key prefix for gateway-side records; the Phase E connector writes its
-# matching records under connector/ in the same bucket.
-AUDIT_PREFIX = os.environ.get("TPAI_AUDIT_PREFIX", "gateway/")
+# Deliberately a constant, NOT an env var: the task role's IAM grant is
+# pinned to exactly this prefix (gateway/*), so any other value turns every
+# put into AccessDenied — and fail-closed turns that into a tool-call
+# outage. Changing the prefix requires a CDK change anyway; keep the two
+# pinned together. (The Phase E connector writes under connector/.)
+AUDIT_PREFIX = "gateway/"
 
 SCHEMA = "tpai.gateway.tool-call.v1"
 
 VALID_POLICY_DECISIONS = ("allow", "deny")
 VALID_OUTCOMES = ("success", "denied", "error", "timeout")
 
-# The audit put sits on the tool-call critical path (fail closed), so keep
-# its worst case bounded: tight timeouts, standard retries — unlike the
-# long-lived streaming config used for Bedrock calls.
+# The audit put sits on the tool-call critical path (fail closed) and each
+# in-flight call pins a threadpool thread, so the worst case must stay small:
+# 2 attempts x (3s connect + 5s read) + backoff ≈ ~17s ceiling for a <1KB
+# put to a same-region gateway endpoint — vs ~50s with boto3's defaults.
 _S3_CONFIG = Config(
-    connect_timeout=5,
-    read_timeout=10,
-    retries={"max_attempts": 3, "mode": "standard"},
+    connect_timeout=3,
+    read_timeout=5,
+    retries={"max_attempts": 2, "mode": "standard"},
 )
 
 _s3_lock = threading.Lock()
@@ -153,6 +157,10 @@ def emit_audit_record(
             Key=key,
             Body=body,
             ContentType="application/json",
+            # Object Lock buckets require a Content-MD5/x-amz-checksum header.
+            # botocore >= 1.36 would add one by default; pass it explicitly so
+            # the invariant doesn't live in a transitive SDK default.
+            ChecksumAlgorithm="CRC32",
         )
     except Exception as exc:
         # Never log record fields here: the full URL belongs only in the

--- a/src/api/identity.py
+++ b/src/api/identity.py
@@ -1,0 +1,90 @@
+"""Per-user identity at ingestion (TPAI external-content program, m1 Phase A).
+
+The gateway derives a pseudonymous per-user identity from trusted headers
+(D7 — trust root is OWUI's asserted header, made non-spoofable by network
+scoping + API-key rotation, not by cryptography):
+
+- OWUI traffic:      ``X-OpenWebUI-User-Email``  (raw email — hashed immediately)
+- api-proxy traffic: ``X-TPAI-ApiKey-User``      (the ``tpai-api-keys`` per-user
+  id, already pseudonymous; the api-proxy strips any inbound identity headers
+  before asserting this one)
+
+Identity = HMAC-SHA256 over a domain-separated input, keyed with a dedicated
+Product-account secret (``TPAI_IDENTITY_HMAC_KEY``, decision E2). This key is
+never billing's Services-account HMAC secret — the audit and billing pseudonym
+spaces must stay unlinkable without both keys.
+
+The raw email has exactly one line of existence in this process: the
+``_identity_hmac(...)`` call inside ``require_identity``. It must never be
+logged, stored, or attached to request state — the log-capture test in
+``tests/test_identity.py`` asserts this.
+
+Enforcement is active iff ``TPAI_IDENTITY_HMAC_KEY`` is configured. The E1
+flag-day change-set injects the key via ECS container secrets; a plain
+CloudFormation rollback removes it and restores pre-flip behavior without
+re-tagging the container image (task definitions reference ``:latest``, so a
+code-level kill switch would otherwise force an image rollback too).
+"""
+
+import hashlib
+import hmac
+import logging
+import os
+
+from fastapi import HTTPException, Request, status
+
+logger = logging.getLogger(__name__)
+
+OWUI_EMAIL_HEADER = "X-OpenWebUI-User-Email"
+API_PROXY_USER_HEADER = "X-TPAI-ApiKey-User"
+
+IDENTITY_HMAC_KEY = os.environ.get("TPAI_IDENTITY_HMAC_KEY", "")
+
+if IDENTITY_HMAC_KEY:
+    logger.info("TPAI identity enforcement ENABLED (identity HMAC key configured)")
+else:
+    logger.warning(
+        "TPAI identity enforcement DISABLED (TPAI_IDENTITY_HMAC_KEY not set) - "
+        "identity-required routes will not demand user identity headers"
+    )
+
+
+def _identity_hmac(domain: str, value: str) -> str:
+    """HMAC-SHA256 of a domain-separated identity input, hex-encoded."""
+    message = f"{domain}:{value}".encode("utf-8")
+    return hmac.new(IDENTITY_HMAC_KEY.encode("utf-8"), message, hashlib.sha256).hexdigest()
+
+
+async def require_identity(request: Request) -> str | None:
+    """FastAPI dependency: resolve the caller's pseudonymous identity.
+
+    Rejects requests that carry no identity header (401) or conflicting
+    identity headers (400 — exactly one trusted proxy must assert identity).
+    The resolved HMAC identity is stored on ``request.state.tpai_identity``
+    for downstream audit/budget consumers.
+    """
+    if not IDENTITY_HMAC_KEY:
+        # Pre-flip (or rolled-back) deployment: no key, no enforcement.
+        return None
+
+    email = (request.headers.get(OWUI_EMAIL_HEADER) or "").strip()
+    api_user = (request.headers.get(API_PROXY_USER_HEADER) or "").strip()
+
+    if email and api_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Conflicting user identity headers",
+        )
+
+    if email:
+        identity = _identity_hmac("owui-email", email.lower())
+    elif api_user:
+        identity = _identity_hmac("api-key-user", api_user.lower())
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing user identity",
+        )
+
+    request.state.tpai_identity = identity
+    return identity

--- a/src/api/identity.py
+++ b/src/api/identity.py
@@ -20,10 +20,16 @@ logged, stored, or attached to request state — the log-capture test in
 ``tests/test_identity.py`` asserts this.
 
 Enforcement is active iff ``TPAI_IDENTITY_HMAC_KEY`` is configured. The E1
-flag-day change-set injects the key via ECS container secrets; a plain
-CloudFormation rollback removes it and restores pre-flip behavior without
-re-tagging the container image (task definitions reference ``:latest``, so a
-code-level kill switch would otherwise force an image rollback too).
+flag-day change-set injects the key via ECS container secrets together with
+``TPAI_IDENTITY_ENFORCE=true``; a plain CloudFormation rollback removes both
+and restores pre-flip behavior without re-tagging the container image (task
+definitions reference ``:latest``, so a code-level kill switch would
+otherwise force an image rollback too).
+
+CAUTION for live task-definition surgery (the phase4-MFA-style incident
+rollback): removing only the HMAC key while ``TPAI_IDENTITY_ENFORCE`` stays
+``true`` intentionally CRASHES the container at startup (fail closed).
+Disable both together, or roll back the whole template.
 """
 
 import hashlib

--- a/src/api/identity.py
+++ b/src/api/identity.py
@@ -39,6 +39,21 @@ OWUI_EMAIL_HEADER = "X-OpenWebUI-User-Email"
 API_PROXY_USER_HEADER = "X-TPAI-ApiKey-User"
 
 IDENTITY_HMAC_KEY = os.environ.get("TPAI_IDENTITY_HMAC_KEY", "")
+IDENTITY_ENFORCE = os.environ.get("TPAI_IDENTITY_ENFORCE", "false").lower() == "true"
+
+
+def _require_key_when_enforced(enforce: bool, key: str) -> None:
+    """Fail closed: a deployment that declares enforcement but lost the key
+    (bad task revision, secret-injection failure, drifted CDK) must crash at
+    startup rather than boot healthy with the identity control silently off."""
+    if enforce and not key:
+        raise RuntimeError(
+            "TPAI_IDENTITY_ENFORCE is set but TPAI_IDENTITY_HMAC_KEY is missing - "
+            "refusing to start with identity enforcement silently disabled"
+        )
+
+
+_require_key_when_enforced(IDENTITY_ENFORCE, IDENTITY_HMAC_KEY)
 
 if IDENTITY_HMAC_KEY:
     logger.info("TPAI identity enforcement ENABLED (identity HMAC key configured)")
@@ -65,10 +80,13 @@ async def require_identity(request: Request) -> str | None:
     """
     if not IDENTITY_HMAC_KEY:
         # Pre-flip (or rolled-back) deployment: no key, no enforcement.
+        # Still set the attribute so downstream consumers can read it
+        # unconditionally in every enforcement state.
+        request.state.tpai_identity = None
         return None
 
-    email = (request.headers.get(OWUI_EMAIL_HEADER) or "").strip()
-    api_user = (request.headers.get(API_PROXY_USER_HEADER) or "").strip()
+    email = (request.headers.get(OWUI_EMAIL_HEADER) or "").strip().lower()
+    api_user = (request.headers.get(API_PROXY_USER_HEADER) or "").strip().lower()
 
     if email and api_user:
         raise HTTPException(
@@ -77,9 +95,9 @@ async def require_identity(request: Request) -> str | None:
         )
 
     if email:
-        identity = _identity_hmac("owui-email", email.lower())
+        identity = _identity_hmac("owui-email", email)
     elif api_user:
-        identity = _identity_hmac("api-key-user", api_user.lower())
+        identity = _identity_hmac("api-key-user", api_user)
     else:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/src/api/models/base.py
+++ b/src/api/models/base.py
@@ -24,6 +24,13 @@ class BaseChatModel(ABC):
     Currently, only Bedrock model is supported, but may be used for SageMaker models if needed.
     """
 
+    # Streaming metadata contract, read by the access log once the stream
+    # ends: chat_stream implementations must set stream_usage when the
+    # provider reports token usage, and stream_error when they swallow a
+    # failure into an in-band SSE error event.
+    stream_usage = None
+    stream_error = False
+
     def list_models(self) -> list[str]:
         """Return a list of supported models"""
         return []

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -13,6 +13,10 @@ from botocore.config import Config
 from fastapi import HTTPException
 from starlette.concurrency import run_in_threadpool
 
+# Early import logging to catch any issues
+logger = logging.getLogger(__name__)
+logger.info("🟢 BEDROCK.PY: Starting imports - EARLY INSTRUMENTATION CHECK")
+
 from api.models.base import BaseChatModel, BaseEmbeddingsModel
 from api.schema import (
     AssistantMessage,
@@ -89,21 +93,40 @@ SUPPORTED_BEDROCK_EMBEDDING_MODELS = {
     # "amazon.titan-embed-image-v1": "Titan Multimodal Embeddings G1"
 }
 
-# Lazy tiktoken initialization
+# Lazy tiktoken initialization with comprehensive logging
 ENCODER = None
+
+logger.info("🚀 BEDROCK.PY MODULE LOADING - Starting module import")
+logger.info(f"🔒 ENABLE_TIKTOKEN_DECODING = {ENABLE_TIKTOKEN_DECODING}")
+logger.info("📅 CODE VERSION: LAZY_TIKTOKEN_V2_WITH_INSTRUMENTATION_2025_07_21")
+logger.info("✅ BEDROCK.PY MODULE LOADED - tiktoken import deferred successfully")
+
+# If you see this in logs, the new code is deployed correctly
+logger.info("🎯 VERIFICATION: This message proves lazy tiktoken code is active")
 
 def _get_tiktoken_encoder():
     """Lazy initialization of tiktoken encoder - only imports when actually needed"""
     global ENCODER
+    logger.info(f"🔍 _get_tiktoken_encoder() called - ENCODER={ENCODER}, ENABLE_TIKTOKEN_DECODING={ENABLE_TIKTOKEN_DECODING}")
+    
     if ENCODER is None and ENABLE_TIKTOKEN_DECODING:
+        logger.info("📥 Attempting lazy tiktoken import...")
         try:
             import tiktoken  # Import only when needed, not at module level
+            logger.info("📦 tiktoken imported successfully, getting encoding...")
             ENCODER = tiktoken.get_encoding("cl100k_base")
-            logger.info("tiktoken encoder initialized successfully")
+            logger.info("✅ tiktoken encoder initialized successfully")
         except Exception as e:
-            logger.warning(f"Failed to initialize tiktoken encoder: {e}")
+            logger.error(f"❌ Failed to initialize tiktoken encoder: {e}")
             ENCODER = False  # Use False to indicate failed initialization
-    return ENCODER if ENCODER is not False else None
+    elif ENCODER is None:
+        logger.info("🚫 tiktoken decoding disabled, skipping initialization")
+    else:
+        logger.info(f"♻️ Using cached tiktoken encoder: {type(ENCODER)}")
+    
+    result = ENCODER if ENCODER is not False else None
+    logger.info(f"🔄 _get_tiktoken_encoder() returning: {type(result)}")
+    return result
 
 
 def list_bedrock_models() -> dict:

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -248,14 +248,14 @@ class BedrockModel(BaseChatModel):
             )
 
     async def _invoke_bedrock(self, chat_request: ChatRequest, stream=False):
-        """Common logic for invoke bedrock models"""
-        if DEBUG:
-            logger.info("Raw request: " + chat_request.model_dump_json())
+        """Common logic for invoke bedrock models.
 
+        Deliberately no request/response body logging here — not even behind
+        DEBUG (external-content decision E3): message content must never
+        reach CloudWatch. Metadata-only logging lives in api.access_log.
+        """
         # convert OpenAI chat request to Bedrock SDK request
         args = self._parse_request(chat_request)
-        if DEBUG:
-            logger.info("Bedrock request: " + json.dumps(str(args)))
 
         try:
             if stream:
@@ -296,8 +296,6 @@ class BedrockModel(BaseChatModel):
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
-        if DEBUG:
-            logger.info("Proxy response :" + chat_response.model_dump_json())
         return chat_response
 
     async def _async_iterate(self, stream):
@@ -307,7 +305,14 @@ class BedrockModel(BaseChatModel):
             yield chunk
 
     async def chat_stream(self, chat_request: ChatRequest) -> AsyncIterable[bytes]:
-        """Default implementation for Chat Stream API"""
+        """Default implementation for Chat Stream API.
+
+        Records ``stream_usage`` (token counts from the Bedrock metadata
+        chunk) and ``stream_error`` on the instance so the router can emit
+        the metadata-only access-log line once the stream finishes.
+        """
+        self.stream_usage = None
+        self.stream_error = False
         try:
             response = await self._invoke_bedrock(chat_request, stream=True)
             message_id = self.generate_message_id()
@@ -317,8 +322,8 @@ class BedrockModel(BaseChatModel):
                 stream_response = self._create_response_stream(**args)
                 if not stream_response:
                     continue
-                if DEBUG:
-                    logger.info("Proxy response :" + stream_response.model_dump_json())
+                if stream_response.usage:
+                    self.stream_usage = stream_response.usage
                 if stream_response.choices:
                     yield self.stream_response_to_bytes(stream_response)
                 elif chat_request.stream_options and chat_request.stream_options.include_usage:
@@ -333,6 +338,7 @@ class BedrockModel(BaseChatModel):
             # return an [DONE] message at the end.
             yield self.stream_response_to_bytes()
         except Exception as e:
+            self.stream_error = True
             logger.error("Stream error for model %s: %s", chat_request.model, str(e))
             error_event = Error(error=ErrorMessage(message=str(e)))
             yield self.stream_response_to_bytes(error_event)
@@ -703,9 +709,6 @@ class BedrockModel(BaseChatModel):
 
         Ref: https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#message-inference-examples
         """
-        if DEBUG:
-            logger.info("Bedrock response chunk: " + str(chunk))
-
         finish_reason = None
         message = None
         usage = None
@@ -938,8 +941,8 @@ class BedrockEmbeddingsModel(BaseEmbeddingsModel, ABC):
     def _invoke_model(self, args: dict, model_id: str):
         body = json.dumps(args)
         if DEBUG:
+            # Model id only — request bodies are never logged (E3).
             logger.info("Invoke Bedrock Model: " + model_id)
-            logger.info("Bedrock request body: " + body)
         try:
             return bedrock_runtime.invoke_model(
                 body=body,
@@ -982,8 +985,6 @@ class BedrockEmbeddingsModel(BaseEmbeddingsModel, ABC):
                 total_tokens=input_tokens + output_tokens,
             ),
         )
-        if DEBUG:
-            logger.info("Proxy response :" + response.model_dump_json())
         return response
 
 
@@ -1031,9 +1032,6 @@ class CohereEmbeddingsModel(BedrockEmbeddingsModel):
             args=self._parse_args(embeddings_request), model_id=embeddings_request.model
         )
         response_body = json.loads(response.get("body").read())
-        if DEBUG:
-            logger.info("Bedrock response body: " + str(response_body))
-
         return self._create_response(
             embeddings=response_body["embeddings"],
             model=embeddings_request.model,
@@ -1071,9 +1069,6 @@ class TitanEmbeddingsModel(BedrockEmbeddingsModel):
             args=self._parse_args(embeddings_request), model_id=embeddings_request.model
         )
         response_body = json.loads(response.get("body").read())
-        if DEBUG:
-            logger.info("Bedrock response body: " + str(response_body))
-
         return self._create_response(
             embeddings=[response_body["embedding"]],
             model=embeddings_request.model,

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -565,10 +565,12 @@ class BedrockModel(BaseChatModel):
 
         # Base inference parameters.
         inference_config = {
-            "temperature": chat_request.temperature,
             "maxTokens": chat_request.max_tokens,
-            "topP": chat_request.top_p,
         }
+        if chat_request.temperature is not None:
+            inference_config["temperature"] = chat_request.temperature
+        if chat_request.top_p is not None:
+            inference_config["topP"] = chat_request.top_p
 
         if chat_request.stop is not None:
             stop = chat_request.stop
@@ -596,11 +598,17 @@ class BedrockModel(BaseChatModel):
             )
             inference_config["maxTokens"] = max_tokens
             # unset topP - Not supported
-            inference_config.pop("topP")
+            inference_config.pop("topP", None)
 
             args["additionalModelRequestFields"] = {
                 "reasoning_config": {"type": "enabled", "budget_tokens": budget_tokens}
             }
+
+        # Anthropic models reject requests with both temperature and top_p.
+        # Drop top_p, keeping temperature as the primary sampling control.
+        if "anthropic" in chat_request.model.lower():
+            inference_config.pop("topP", None)
+
         # add tool config
         if chat_request.tools:
             tool_config = {"tools": [self._convert_tool_spec(t.function) for t in chat_request.tools]}

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -1,10 +1,10 @@
 import time
-from typing import Annotated, AsyncIterable
+from typing import Annotated, AsyncIterable, Callable
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from api.access_log import emit_chat_access_log
+from api.access_log import emit_access_log
 from api.auth import api_key_auth
 from api.identity import require_identity
 from api.models.bedrock import BedrockModel
@@ -21,30 +21,29 @@ router = APIRouter(
 async def _stream_with_access_log(
     model: BedrockModel,
     chat_request: ChatRequest,
-    identity: str | None,
-    started: float,
+    emit: Callable[..., None],
 ) -> AsyncIterable[bytes]:
     """Pass the stream through untouched; emit the metadata line at the end.
 
     ``chat_stream`` converts internal errors into an SSE error event on a
-    wire-status-200 response, recording ``stream_error`` on the model — the
-    outcome field reflects that even though the HTTP status cannot.
+    wire-status-200 response, recording ``stream_error`` on the model — so
+    outcome, not status, reflects streaming failures. A client disconnect
+    surfaces as GeneratorExit and is recorded as ``aborted``.
     """
+    outcome = "success"
     try:
         async for chunk in model.chat_stream(chat_request):
             yield chunk
+    except GeneratorExit:
+        outcome = "aborted"
+        raise
+    except BaseException:
+        outcome = "error"
+        raise
     finally:
-        usage = getattr(model, "stream_usage", None)
-        emit_chat_access_log(
-            identity=identity,
-            model=chat_request.model,
-            stream=True,
-            status=200,
-            latency_ms=int((time.monotonic() - started) * 1000),
-            prompt_tokens=usage.prompt_tokens if usage else None,
-            completion_tokens=usage.completion_tokens if usage else None,
-            outcome="error" if getattr(model, "stream_error", False) else "success",
-        )
+        if model.stream_error:
+            outcome = "error"
+        emit(stream=True, status=200, outcome=outcome, usage=model.stream_usage)
 
 
 @router.post(
@@ -73,38 +72,36 @@ async def chat_completions(
     if chat_request.model.lower().startswith("gpt-"):
         chat_request.model = DEFAULT_MODEL
 
-    model = BedrockModel()
+    def emit(*, stream: bool, status: int, outcome: str, usage=None) -> None:
+        emit_access_log(
+            event="chat_completion",
+            identity=identity,
+            model=chat_request.model,
+            stream=stream,
+            status=status,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            prompt_tokens=usage.prompt_tokens if usage else None,
+            completion_tokens=usage.completion_tokens if usage else None,
+            outcome=outcome,
+        )
+
     try:
+        model = BedrockModel()
         # Exception will be raised if model not supported.
         model.validate(chat_request)
         if chat_request.stream:
             return StreamingResponse(
-                content=_stream_with_access_log(model, chat_request, identity, started),
+                content=_stream_with_access_log(model, chat_request, emit),
                 media_type="text/event-stream",
             )
         response = await model.chat(chat_request)
     except Exception as exc:
-        emit_chat_access_log(
-            identity=identity,
-            model=chat_request.model,
-            stream=chat_request.stream,
+        emit(
+            stream=bool(chat_request.stream),
             status=exc.status_code if isinstance(exc, HTTPException) else 500,
-            latency_ms=int((time.monotonic() - started) * 1000),
-            prompt_tokens=None,
-            completion_tokens=None,
             outcome="error",
         )
         raise
 
-    usage = response.usage
-    emit_chat_access_log(
-        identity=identity,
-        model=chat_request.model,
-        stream=False,
-        status=200,
-        latency_ms=int((time.monotonic() - started) * 1000),
-        prompt_tokens=usage.prompt_tokens if usage else None,
-        completion_tokens=usage.completion_tokens if usage else None,
-        outcome="success",
-    )
+    emit(stream=False, status=200, outcome="success", usage=response.usage)
     return response

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends
@@ -7,6 +8,8 @@ from api.auth import api_key_auth
 from api.models.bedrock import BedrockModel
 from api.schema import ChatRequest, ChatResponse, ChatStreamResponse, Error
 from api.setting import DEFAULT_MODEL
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/chat",
@@ -34,6 +37,8 @@ async def chat_completions(
         ),
     ],
 ):
+    logger.warning(f"[TPAI-DIAG] /chat/completions received: model={chat_request.model} messages={len(chat_request.messages)} stream={chat_request.stream}")
+
     if chat_request.model.lower().startswith("gpt-"):
         chat_request.model = DEFAULT_MODEL
 
@@ -41,5 +46,8 @@ async def chat_completions(
     model = BedrockModel()
     model.validate(chat_request)
     if chat_request.stream:
+        logger.warning(f"[TPAI-DIAG] Streaming response for model={chat_request.model}")
         return StreamingResponse(content=model.chat_stream(chat_request), media_type="text/event-stream")
-    return await model.chat(chat_request)
+    response = await model.chat(chat_request)
+    logger.warning(f"[TPAI-DIAG] Non-stream response for model={chat_request.model}: {str(response)[:200]}")
+    return response

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -1,16 +1,15 @@
-import logging
-from typing import Annotated
+import time
+from typing import Annotated, AsyncIterable
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from api.access_log import emit_chat_access_log
 from api.auth import api_key_auth
 from api.identity import require_identity
 from api.models.bedrock import BedrockModel
 from api.schema import ChatRequest, ChatResponse, ChatStreamResponse, Error
 from api.setting import DEFAULT_MODEL
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/chat",
@@ -19,10 +18,40 @@ router = APIRouter(
 )
 
 
+async def _stream_with_access_log(
+    model: BedrockModel,
+    chat_request: ChatRequest,
+    identity: str | None,
+    started: float,
+) -> AsyncIterable[bytes]:
+    """Pass the stream through untouched; emit the metadata line at the end.
+
+    ``chat_stream`` converts internal errors into an SSE error event on a
+    wire-status-200 response, recording ``stream_error`` on the model — the
+    outcome field reflects that even though the HTTP status cannot.
+    """
+    try:
+        async for chunk in model.chat_stream(chat_request):
+            yield chunk
+    finally:
+        usage = getattr(model, "stream_usage", None)
+        emit_chat_access_log(
+            identity=identity,
+            model=chat_request.model,
+            stream=True,
+            status=200,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            prompt_tokens=usage.prompt_tokens if usage else None,
+            completion_tokens=usage.completion_tokens if usage else None,
+            outcome="error" if getattr(model, "stream_error", False) else "success",
+        )
+
+
 @router.post(
     "/completions", response_model=ChatResponse | ChatStreamResponse | Error, response_model_exclude_unset=True
 )
 async def chat_completions(
+    request: Request,
     chat_request: Annotated[
         ChatRequest,
         Body(
@@ -38,17 +67,44 @@ async def chat_completions(
         ),
     ],
 ):
-    logger.warning(f"[TPAI-DIAG] /chat/completions received: model={chat_request.model} messages={len(chat_request.messages)} stream={chat_request.stream}")
+    started = time.monotonic()
+    identity = getattr(request.state, "tpai_identity", None)
 
     if chat_request.model.lower().startswith("gpt-"):
         chat_request.model = DEFAULT_MODEL
 
-    # Exception will be raised if model not supported.
     model = BedrockModel()
-    model.validate(chat_request)
-    if chat_request.stream:
-        logger.warning(f"[TPAI-DIAG] Streaming response for model={chat_request.model}")
-        return StreamingResponse(content=model.chat_stream(chat_request), media_type="text/event-stream")
-    response = await model.chat(chat_request)
-    logger.warning(f"[TPAI-DIAG] Non-stream response for model={chat_request.model}: {str(response)[:200]}")
+    try:
+        # Exception will be raised if model not supported.
+        model.validate(chat_request)
+        if chat_request.stream:
+            return StreamingResponse(
+                content=_stream_with_access_log(model, chat_request, identity, started),
+                media_type="text/event-stream",
+            )
+        response = await model.chat(chat_request)
+    except Exception as exc:
+        emit_chat_access_log(
+            identity=identity,
+            model=chat_request.model,
+            stream=chat_request.stream,
+            status=exc.status_code if isinstance(exc, HTTPException) else 500,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            prompt_tokens=None,
+            completion_tokens=None,
+            outcome="error",
+        )
+        raise
+
+    usage = response.usage
+    emit_chat_access_log(
+        identity=identity,
+        model=chat_request.model,
+        stream=False,
+        status=200,
+        latency_ms=int((time.monotonic() - started) * 1000),
+        prompt_tokens=usage.prompt_tokens if usage else None,
+        completion_tokens=usage.completion_tokens if usage else None,
+        outcome="success",
+    )
     return response

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Body, Depends
 from fastapi.responses import StreamingResponse
 
 from api.auth import api_key_auth
+from api.identity import require_identity
 from api.models.bedrock import BedrockModel
 from api.schema import ChatRequest, ChatResponse, ChatStreamResponse, Error
 from api.setting import DEFAULT_MODEL
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/chat",
-    dependencies=[Depends(api_key_auth)],
+    dependencies=[Depends(api_key_auth), Depends(require_identity)],
     # responses={404: {"description": "Not found"}},
 )
 

--- a/src/api/routers/embeddings.py
+++ b/src/api/routers/embeddings.py
@@ -1,7 +1,9 @@
+import time
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
 
+from api.access_log import emit_access_log
 from api.auth import api_key_auth
 from api.identity import require_identity
 from api.models.bedrock import get_embeddings_model
@@ -16,6 +18,7 @@ router = APIRouter(
 
 @router.post("", response_model=EmbeddingsResponse)
 async def embeddings(
+    request: Request,
     embeddings_request: Annotated[
         EmbeddingsRequest,
         Body(
@@ -28,8 +31,35 @@ async def embeddings(
         ),
     ],
 ):
+    started = time.monotonic()
+    identity = getattr(request.state, "tpai_identity", None)
+
     if embeddings_request.model.lower().startswith("text-embedding-"):
         embeddings_request.model = DEFAULT_EMBEDDING_MODEL
-    # Exception will be raised if model not supported.
-    model = get_embeddings_model(embeddings_request.model)
-    return model.embed(embeddings_request)
+
+    def emit(*, status: int, outcome: str, usage=None) -> None:
+        emit_access_log(
+            event="embeddings",
+            identity=identity,
+            model=embeddings_request.model,
+            stream=None,
+            status=status,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            prompt_tokens=usage.prompt_tokens if usage else None,
+            completion_tokens=None,
+            outcome=outcome,
+        )
+
+    try:
+        # Exception will be raised if model not supported.
+        model = get_embeddings_model(embeddings_request.model)
+        response = model.embed(embeddings_request)
+    except Exception as exc:
+        emit(
+            status=exc.status_code if isinstance(exc, HTTPException) else 500,
+            outcome="error",
+        )
+        raise
+
+    emit(status=200, outcome="success", usage=response.usage)
+    return response

--- a/src/api/routers/embeddings.py
+++ b/src/api/routers/embeddings.py
@@ -3,13 +3,14 @@ from typing import Annotated
 from fastapi import APIRouter, Body, Depends
 
 from api.auth import api_key_auth
+from api.identity import require_identity
 from api.models.bedrock import get_embeddings_model
 from api.schema import EmbeddingsRequest, EmbeddingsResponse
 from api.setting import DEFAULT_EMBEDDING_MODEL
 
 router = APIRouter(
     prefix="/embeddings",
-    dependencies=[Depends(api_key_auth)],
+    dependencies=[Depends(api_key_auth), Depends(require_identity)],
 )
 
 

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -97,8 +97,8 @@ class ChatRequest(BaseModel):
     presence_penalty: float | None = Field(default=0.0, le=2.0, ge=-2.0)  # Not used
     stream: bool | None = False
     stream_options: StreamOptions | None = None
-    temperature: float | None = Field(default=1.0, le=2.0, ge=0.0)
-    top_p: float | None = Field(default=1.0, le=1.0, ge=0.0)
+    temperature: float | None = Field(default=None, le=2.0, ge=0.0)
+    top_p: float | None = Field(default=None, le=1.0, ge=0.0)
     user: str | None = None  # Not used
     max_tokens: int | None = 2048
     max_completion_tokens: int | None = None

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -17,3 +17,4 @@ DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240
 DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3")
 ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
 ENABLE_APPLICATION_INFERENCE_PROFILES = os.environ.get("ENABLE_APPLICATION_INFERENCE_PROFILES", "true").lower() != "false"
+ENABLE_TIKTOKEN_DECODING = os.environ.get("ENABLE_TIKTOKEN_DECODING", "false").lower() != "false"

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -18,3 +18,24 @@ DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embe
 ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
 ENABLE_APPLICATION_INFERENCE_PROFILES = os.environ.get("ENABLE_APPLICATION_INFERENCE_PROFILES", "true").lower() != "false"
 ENABLE_TIKTOKEN_DECODING = os.environ.get("ENABLE_TIKTOKEN_DECODING", "false").lower() != "false"
+
+# --- Built-in web_fetch tool ---------------------------------------------------
+# Master switch for the server-side web_fetch tool. Default OFF so the gateway
+# behaves identically to before until egress + allowlist are in place.
+ENABLE_WEB_FETCH_TOOL = os.environ.get("ENABLE_WEB_FETCH_TOOL", "false").lower() != "false"
+# When false, web_fetch is only injected for Anthropic (Claude) models. Set true
+# to offer it to every tool-capable Converse model.
+WEB_FETCH_MODELS_ALL = os.environ.get("WEB_FETCH_MODELS_ALL", "false").lower() != "false"
+# Max number of server-side fetch rounds before the gateway forces a final answer.
+WEB_FETCH_MAX_ITERATIONS = int(os.environ.get("WEB_FETCH_MAX_ITERATIONS", "4"))
+# Per-request read timeout (seconds) for a single fetch.
+WEB_FETCH_TIMEOUT_S = int(os.environ.get("WEB_FETCH_TIMEOUT_S", "8"))
+# Hard cap on bytes downloaded per fetch (default 2 MiB).
+WEB_FETCH_MAX_BYTES = int(os.environ.get("WEB_FETCH_MAX_BYTES", str(2 * 1024 * 1024)))
+# Hard cap on extracted characters returned to the model per fetch.
+WEB_FETCH_MAX_CHARS = int(os.environ.get("WEB_FETCH_MAX_CHARS", "50000"))
+# Comma-separated domain allowlist (defense-in-depth on top of the Squid proxy).
+# Empty = allow any domain that passes the SSRF guard and the proxy allowlist.
+WEB_FETCH_ALLOWED_DOMAINS = os.environ.get("WEB_FETCH_ALLOWED_DOMAINS", "")
+# Surface a "🔎 Fetching <host>…" status line into the stream when fetching.
+WEB_FETCH_STREAM_STATUS = os.environ.get("WEB_FETCH_STREAM_STATUS", "false").lower() != "false"

--- a/src/entrypoint_tls.sh
+++ b/src/entrypoint_tls.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Generate a fresh self-signed certificate on every container start, then run
+# uvicorn with TLS. The key never leaves the container's filesystem and is
+# regenerated on every task launch — nothing to rotate or store.
+#
+# TPAI HIPAA M1.2 (§164.312(e)): this encrypts the ALB→container hop. The ALB
+# does not validate target certificates by design, so self-signed is the
+# standard pattern for this hop.
+set -eu
+
+CERT_DIR=/tmp/tls
+mkdir -p "$CERT_DIR"
+
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -days 3650 \
+  -keyout "$CERT_DIR/tls.key" \
+  -out "$CERT_DIR/tls.crt" \
+  -subj "/CN=bedrock-gateway.local" \
+  >/dev/null 2>&1
+
+chmod 600 "$CERT_DIR/tls.key"
+echo "bedrock-gateway: self-signed certificate generated, starting uvicorn with TLS on port ${PORT:-443}"
+
+exec uvicorn api.app:app --host 0.0.0.0 --port "${PORT:-443}" \
+  --ssl-keyfile "$CERT_DIR/tls.key" \
+  --ssl-certfile "$CERT_DIR/tls.crt"

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -q

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+httpx==0.27.2

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -7,9 +7,11 @@ Environment must be configured before ``api.*`` modules import: both
 import os
 
 # Exercise the same env-var paths production uses (ECS container secrets
-# inject API_KEY and TPAI_IDENTITY_HMAC_KEY as plain env vars).
-os.environ.setdefault("API_KEY", "test-gateway-api-key")
-os.environ.setdefault("TPAI_IDENTITY_HMAC_KEY", "test-identity-hmac-key")
+# inject API_KEY and TPAI_IDENTITY_HMAC_KEY as plain env vars). Hard-assign
+# (not setdefault) so a developer's exported real credentials can never
+# leak into — or silently redefine — the test fixtures.
+os.environ["API_KEY"] = "test-gateway-api-key"
+os.environ["TPAI_IDENTITY_HMAC_KEY"] = "test-identity-hmac-key"
 os.environ.setdefault("AWS_REGION", "us-east-1")
 # Hermetic tests: never inherit the developer's AWS profile/credentials —
 # api.models.bedrock creates boto3 clients at import time, which resolves

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -43,7 +43,11 @@ CANNED_RESPONSE = ChatResponse(
 
 
 class StubBedrockModel:
-    """Stands in for BedrockModel so tests never touch AWS."""
+    """Stands in for BedrockModel so tests never touch AWS.
+
+    Mirrors the streaming contract the access log relies on: chat_stream
+    records ``stream_usage`` / ``stream_error`` on the instance.
+    """
 
     def validate(self, chat_request):
         return None
@@ -51,7 +55,11 @@ class StubBedrockModel:
     async def chat(self, chat_request):
         return CANNED_RESPONSE
 
-    def chat_stream(self, chat_request):
+    async def chat_stream(self, chat_request):
+        self.stream_usage = None
+        self.stream_error = False
+        yield b'data: {"choices":[{"delta":{"content":"Hello."}}]}\n\n'
+        self.stream_usage = CANNED_RESPONSE.usage
         yield b"data: [DONE]\n\n"
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -15,6 +15,10 @@ import os
 IDENTITY_TEST_KEY = "test-identity-hmac-key"
 os.environ["API_KEY"] = "test-gateway-api-key"
 os.environ["TPAI_IDENTITY_HMAC_KEY"] = IDENTITY_TEST_KEY
+# api.audit reads TPAI_AUDIT_BUCKET at import time: drop any real value so a
+# test that forgets to stub the S3 client can never PUT to a real audit
+# bucket (fixtures monkeypatch audit.AUDIT_BUCKET explicitly).
+os.environ.pop("TPAI_AUDIT_BUCKET", None)
 os.environ.setdefault("AWS_REGION", "us-east-1")
 # Hermetic tests: never inherit the developer's AWS profile/credentials —
 # api.models.bedrock creates boto3 clients at import time, which resolves

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,65 @@
+"""Shared test fixtures for the gateway test suite.
+
+Environment must be configured before ``api.*`` modules import: both
+``api.auth`` and ``api.identity`` read their configuration at import time.
+"""
+
+import os
+
+# Exercise the same env-var paths production uses (ECS container secrets
+# inject API_KEY and TPAI_IDENTITY_HMAC_KEY as plain env vars).
+os.environ.setdefault("API_KEY", "test-gateway-api-key")
+os.environ.setdefault("TPAI_IDENTITY_HMAC_KEY", "test-identity-hmac-key")
+os.environ.setdefault("AWS_REGION", "us-east-1")
+# Hermetic tests: never inherit the developer's AWS profile/credentials —
+# api.models.bedrock creates boto3 clients at import time, which resolves
+# the profile chain even though no API call is ever made.
+os.environ.pop("AWS_PROFILE", None)
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.app import app
+from api.schema import ChatResponse, ChatResponseMessage, Choice, Usage
+
+
+AUTH = {"Authorization": "Bearer test-gateway-api-key"}
+
+CANNED_RESPONSE = ChatResponse(
+    id="chatcmpl-test",
+    model="anthropic.claude-3-sonnet-20240229-v1:0",
+    choices=[
+        Choice(
+            index=0,
+            message=ChatResponseMessage(role="assistant", content="Hello."),
+            finish_reason="stop",
+        )
+    ],
+    usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+)
+
+
+class StubBedrockModel:
+    """Stands in for BedrockModel so tests never touch AWS."""
+
+    def validate(self, chat_request):
+        return None
+
+    async def chat(self, chat_request):
+        return CANNED_RESPONSE
+
+    def chat_stream(self, chat_request):
+        yield b"data: [DONE]\n\n"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr("api.routers.chat.BedrockModel", StubBedrockModel)
+    return TestClient(app)
+
+
+CHAT_BODY = {
+    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "messages": [{"role": "user", "content": "Hello!"}],
+}

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,14 +4,17 @@ Environment must be configured before ``api.*`` modules import: both
 ``api.auth`` and ``api.identity`` read their configuration at import time.
 """
 
+import hashlib
+import hmac
 import os
 
 # Exercise the same env-var paths production uses (ECS container secrets
 # inject API_KEY and TPAI_IDENTITY_HMAC_KEY as plain env vars). Hard-assign
 # (not setdefault) so a developer's exported real credentials can never
 # leak into — or silently redefine — the test fixtures.
+IDENTITY_TEST_KEY = "test-identity-hmac-key"
 os.environ["API_KEY"] = "test-gateway-api-key"
-os.environ["TPAI_IDENTITY_HMAC_KEY"] = "test-identity-hmac-key"
+os.environ["TPAI_IDENTITY_HMAC_KEY"] = IDENTITY_TEST_KEY
 os.environ.setdefault("AWS_REGION", "us-east-1")
 # Hermetic tests: never inherit the developer's AWS profile/credentials —
 # api.models.bedrock creates boto3 clients at import time, which resolves
@@ -23,10 +26,28 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.app import app
-from api.schema import ChatResponse, ChatResponseMessage, Choice, Usage
+from api.schema import (
+    ChatResponse,
+    ChatResponseMessage,
+    Choice,
+    Embedding,
+    EmbeddingsResponse,
+    EmbeddingsUsage,
+    Usage,
+)
 
 
 AUTH = {"Authorization": "Bearer test-gateway-api-key"}
+
+
+def expected_hmac(domain: str, value: str) -> str:
+    """The production identity derivation (api.identity._identity_hmac),
+    restated independently so a drift in the domain-separation contract
+    fails these tests instead of being silently mirrored."""
+    return hmac.new(
+        IDENTITY_TEST_KEY.encode(), f"{domain}:{value}".encode(), hashlib.sha256
+    ).hexdigest()
+
 
 CANNED_RESPONSE = ChatResponse(
     id="chatcmpl-test",
@@ -41,13 +62,22 @@ CANNED_RESPONSE = ChatResponse(
     usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
 )
 
+CANNED_EMBEDDINGS_RESPONSE = EmbeddingsResponse(
+    data=[Embedding(index=0, embedding=[0.1, 0.2, 0.3])],
+    model="cohere.embed-multilingual-v3",
+    usage=EmbeddingsUsage(prompt_tokens=3, total_tokens=3),
+)
+
 
 class StubBedrockModel:
     """Stands in for BedrockModel so tests never touch AWS.
 
-    Mirrors the streaming contract the access log relies on: chat_stream
-    records ``stream_usage`` / ``stream_error`` on the instance.
+    Mirrors the BaseChatModel streaming contract the access log relies on:
+    chat_stream records ``stream_usage`` / ``stream_error`` on the instance.
     """
+
+    stream_usage = None
+    stream_error = False
 
     def validate(self, chat_request):
         return None
@@ -63,9 +93,19 @@ class StubBedrockModel:
         yield b"data: [DONE]\n\n"
 
 
+class StubEmbeddingsModel:
+    """Stands in for the Bedrock embeddings models."""
+
+    def embed(self, embeddings_request):
+        return CANNED_EMBEDDINGS_RESPONSE
+
+
 @pytest.fixture
 def client(monkeypatch):
     monkeypatch.setattr("api.routers.chat.BedrockModel", StubBedrockModel)
+    monkeypatch.setattr(
+        "api.routers.embeddings.get_embeddings_model", lambda model_id: StubEmbeddingsModel()
+    )
     return TestClient(app)
 
 

--- a/src/tests/test_access_log.py
+++ b/src/tests/test_access_log.py
@@ -1,0 +1,221 @@
+"""Log-hygiene tests (external-content m1 Phase B(i) / decision E3).
+
+Two properties, both required by ADR-1 condition 2:
+
+1. **No content in logs** — neither request nor response message content
+   appears in any log record, on any path (non-stream, stream, error), and
+   the deleted DIAG marker is gone from the source tree (drift guard).
+2. **The always-on metadata line exists** — exactly one structured JSON
+   line per chat completion carrying status, latency, token counts, tool,
+   outcome, and the pseudonymous HMAC identity.
+"""
+
+import hashlib
+import hmac
+import json
+import logging
+from pathlib import Path
+
+from fastapi import HTTPException
+
+import api.identity as identity
+from tests.conftest import AUTH, CHAT_BODY, StubBedrockModel
+
+TEST_KEY = "test-identity-hmac-key"
+TEST_EMAIL = "alice@example.com"
+EXPECTED_IDENTITY = hmac.new(
+    TEST_KEY.encode(), f"owui-email:{TEST_EMAIL}".encode(), hashlib.sha256
+).hexdigest()
+IDENTITY_HEADERS = {**AUTH, identity.OWUI_EMAIL_HEADER: TEST_EMAIL}
+
+# Sentinel content that must never surface in a log record.
+SENTINEL = "PHI-SENTINEL patient John Doe, MRN 0012345"
+SENTINEL_BODY = {
+    "model": CHAT_BODY["model"],
+    "messages": [{"role": "user", "content": SENTINEL}],
+}
+
+
+def access_lines(caplog):
+    return [json.loads(r.getMessage()) for r in caplog.records if r.name == "tpai.access"]
+
+
+# --- The metadata line (schema + values) --------------------------------------
+
+
+def test_non_stream_emits_one_metadata_line(client, caplog):
+    caplog.set_level(logging.DEBUG)
+    resp = client.post("/api/v1/chat/completions", json=CHAT_BODY, headers=IDENTITY_HEADERS)
+    assert resp.status_code == 200
+
+    lines = access_lines(caplog)
+    assert len(lines) == 1
+    line = lines[0]
+    assert isinstance(line.pop("latency_ms"), int)
+    assert line == {
+        "event": "chat_completion",
+        "identity": EXPECTED_IDENTITY,
+        "model": CHAT_BODY["model"],
+        "stream": False,
+        "status": 200,
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "tool": None,
+        "outcome": "success",
+    }
+
+
+def test_stream_emits_metadata_line_with_usage(client, caplog):
+    caplog.set_level(logging.DEBUG)
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json={**CHAT_BODY, "stream": True},
+        headers=IDENTITY_HEADERS,
+    )
+    assert resp.status_code == 200
+    assert "[DONE]" in resp.text
+
+    lines = access_lines(caplog)
+    assert len(lines) == 1
+    line = lines[0]
+    assert line["stream"] is True
+    assert line["status"] == 200
+    assert line["outcome"] == "success"
+    assert line["prompt_tokens"] == 1
+    assert line["completion_tokens"] == 1
+    assert line["identity"] == EXPECTED_IDENTITY
+
+
+def test_error_path_emits_metadata_line(client, caplog, monkeypatch):
+    caplog.set_level(logging.DEBUG)
+
+    async def throttled(self, chat_request):
+        raise HTTPException(status_code=429, detail="Too many requests")
+
+    monkeypatch.setattr(StubBedrockModel, "chat", throttled)
+    resp = client.post("/api/v1/chat/completions", json=CHAT_BODY, headers=IDENTITY_HEADERS)
+    assert resp.status_code == 429
+
+    lines = access_lines(caplog)
+    assert len(lines) == 1
+    assert lines[0]["status"] == 429
+    assert lines[0]["outcome"] == "error"
+    assert lines[0]["prompt_tokens"] is None
+
+
+def test_stream_error_recorded_in_outcome(client, caplog, monkeypatch):
+    """chat_stream converts internal failures into an SSE error event on a
+    wire-status-200 response; the metadata line still says outcome=error."""
+    caplog.set_level(logging.DEBUG)
+
+    async def broken_stream(self, chat_request):
+        self.stream_usage = None
+        self.stream_error = True
+        yield b'data: {"error": {"message": "stream failed"}}\n\n'
+
+    monkeypatch.setattr(StubBedrockModel, "chat_stream", broken_stream)
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json={**CHAT_BODY, "stream": True},
+        headers=IDENTITY_HEADERS,
+    )
+    assert resp.status_code == 200
+
+    lines = access_lines(caplog)
+    assert len(lines) == 1
+    assert lines[0]["outcome"] == "error"
+
+
+def test_metadata_line_emitted_when_enforcement_disabled(client, caplog, monkeypatch):
+    """Pre-flip / rolled-back deployments still get the line, identity=null."""
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(identity, "IDENTITY_HMAC_KEY", "")
+    resp = client.post("/api/v1/chat/completions", json=CHAT_BODY, headers=AUTH)
+    assert resp.status_code == 200
+
+    lines = access_lines(caplog)
+    assert len(lines) == 1
+    assert lines[0]["identity"] is None
+
+
+# --- No content in logs, ever (the E3 acceptance property) ---------------------
+
+
+def assert_no_content_logged(caplog, resp_content: str = "Hello."):
+    for record in caplog.records:
+        rendered = record.getMessage()
+        assert SENTINEL not in rendered, (
+            f"request content leaked into log record from {record.name}:{record.lineno}"
+        )
+        assert "John Doe" not in rendered
+        assert resp_content not in rendered, (
+            f"response content leaked into log record from {record.name}:{record.lineno}"
+        )
+
+
+def test_no_content_in_logs_non_stream(client, caplog):
+    caplog.set_level(logging.DEBUG)
+    resp = client.post("/api/v1/chat/completions", json=SENTINEL_BODY, headers=IDENTITY_HEADERS)
+    assert resp.status_code == 200
+    # The response itself carries the assistant content — logs must not.
+    assert "Hello." in resp.text
+    assert_no_content_logged(caplog)
+
+
+def test_no_content_in_logs_stream(client, caplog):
+    caplog.set_level(logging.DEBUG)
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json={**SENTINEL_BODY, "stream": True},
+        headers=IDENTITY_HEADERS,
+    )
+    assert resp.status_code == 200
+    assert "Hello." in resp.text
+    assert_no_content_logged(caplog)
+
+
+def test_no_content_in_logs_on_error_path(client, caplog, monkeypatch):
+    caplog.set_level(logging.DEBUG)
+
+    async def broken(self, chat_request):
+        raise HTTPException(status_code=500, detail="upstream failure")
+
+    monkeypatch.setattr(StubBedrockModel, "chat", broken)
+    resp = client.post("/api/v1/chat/completions", json=SENTINEL_BODY, headers=IDENTITY_HEADERS)
+    assert resp.status_code == 500
+    assert_no_content_logged(caplog)
+
+
+# --- Drift guards ---------------------------------------------------------------
+
+DIAG_MARKER = "TPAI-" + "DIAG"  # split so this file never matches itself
+
+
+def test_no_diag_markers_in_source():
+    """The DIAG-line deletion is permanent — nothing may reintroduce the marker."""
+    src_root = Path(__file__).resolve().parents[1]
+    offenders = [
+        str(path)
+        for path in src_root.rglob("*.py")
+        if "__pycache__" not in path.parts and DIAG_MARKER in path.read_text()
+    ]
+    assert offenders == []
+
+
+def test_no_body_dump_logging_in_source():
+    """No logger call may serialize a request/response object — the historic
+    content sinks were `model_dump_json()` and body/chunk str() dumps fed to
+    logger.info under DEBUG."""
+    src_root = Path(__file__).resolve().parents[1] / "api"
+    offenders = []
+    for path in src_root.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if "logger." in line and (
+                "model_dump_json" in line
+                or "str(response_body)" in line
+                or "str(chunk)" in line
+            ):
+                offenders.append(f"{path}:{lineno}: {line.strip()}")
+    assert offenders == []

--- a/src/tests/test_access_log.py
+++ b/src/tests/test_access_log.py
@@ -6,12 +6,15 @@ Two properties, both required by ADR-1 condition 2:
    appears in any log record, on any path (non-stream, stream, error), and
    the deleted DIAG marker is gone from the source tree (drift guard).
 2. **The always-on metadata line exists** — exactly one structured JSON
-   line per chat completion carrying status, latency, token counts, tool,
+   line per completed request carrying status, latency, token counts, tool,
    outcome, and the pseudonymous HMAC identity.
+
+The behavioral log-capture tests are the primary guard; the source-scan
+drift guards below are a belt-and-braces backstop, not the acceptance
+property itself.
 """
 
-import hashlib
-import hmac
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -19,13 +22,11 @@ from pathlib import Path
 from fastapi import HTTPException
 
 import api.identity as identity
-from tests.conftest import AUTH, CHAT_BODY, StubBedrockModel
+from api.routers.chat import _stream_with_access_log
+from tests.conftest import AUTH, CHAT_BODY, StubBedrockModel, expected_hmac
 
-TEST_KEY = "test-identity-hmac-key"
 TEST_EMAIL = "alice@example.com"
-EXPECTED_IDENTITY = hmac.new(
-    TEST_KEY.encode(), f"owui-email:{TEST_EMAIL}".encode(), hashlib.sha256
-).hexdigest()
+EXPECTED_IDENTITY = expected_hmac("owui-email", TEST_EMAIL)
 IDENTITY_HEADERS = {**AUTH, identity.OWUI_EMAIL_HEADER: TEST_EMAIL}
 
 # Sentinel content that must never surface in a log record.
@@ -103,6 +104,27 @@ def test_error_path_emits_metadata_line(client, caplog, monkeypatch):
     assert lines[0]["prompt_tokens"] is None
 
 
+def test_error_path_stream_field_is_bool(client, caplog, monkeypatch):
+    """ChatRequest.stream is `bool | None`; the error path must coerce None
+    to False so the line's stream field never drifts from the schema."""
+    caplog.set_level(logging.DEBUG)
+
+    async def broken(self, chat_request):
+        raise HTTPException(status_code=500, detail="boom")
+
+    monkeypatch.setattr(StubBedrockModel, "chat", broken)
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json={**CHAT_BODY, "stream": None},
+        headers=IDENTITY_HEADERS,
+    )
+    assert resp.status_code == 500
+
+    lines = access_lines(caplog)
+    assert len(lines) == 1
+    assert lines[0]["stream"] is False
+
+
 def test_stream_error_recorded_in_outcome(client, caplog, monkeypatch):
     """chat_stream converts internal failures into an SSE error event on a
     wire-status-200 response; the metadata line still says outcome=error."""
@@ -126,6 +148,27 @@ def test_stream_error_recorded_in_outcome(client, caplog, monkeypatch):
     assert lines[0]["outcome"] == "error"
 
 
+def test_client_disconnect_recorded_as_aborted():
+    """A client dropping mid-stream closes the generator (GeneratorExit);
+    the line must say aborted, not success."""
+    emitted = []
+
+    async def scenario():
+        model = StubBedrockModel()
+        gen = _stream_with_access_log(
+            model,
+            type("Req", (), {"model": "m"})(),
+            lambda **kw: emitted.append(kw),
+        )
+        await anext(gen)  # first chunk delivered, then the client vanishes
+        await gen.aclose()
+
+    asyncio.run(scenario())
+    assert len(emitted) == 1
+    assert emitted[0]["outcome"] == "aborted"
+    assert emitted[0]["status"] == 200
+
+
 def test_metadata_line_emitted_when_enforcement_disabled(client, caplog, monkeypatch):
     """Pre-flip / rolled-back deployments still get the line, identity=null."""
     caplog.set_level(logging.DEBUG)
@@ -138,6 +181,32 @@ def test_metadata_line_emitted_when_enforcement_disabled(client, caplog, monkeyp
     assert lines[0]["identity"] is None
 
 
+def test_embeddings_emits_metadata_line(client, caplog):
+    caplog.set_level(logging.DEBUG)
+    resp = client.post(
+        "/api/v1/embeddings",
+        json={"model": "cohere.embed-multilingual-v3", "input": ["hi"]},
+        headers=IDENTITY_HEADERS,
+    )
+    assert resp.status_code == 200
+
+    lines = access_lines(caplog)
+    assert len(lines) == 1
+    line = lines[0]
+    assert isinstance(line.pop("latency_ms"), int)
+    assert line == {
+        "event": "embeddings",
+        "identity": EXPECTED_IDENTITY,
+        "model": "cohere.embed-multilingual-v3",
+        "stream": None,
+        "status": 200,
+        "prompt_tokens": 3,
+        "completion_tokens": None,
+        "tool": None,
+        "outcome": "success",
+    }
+
+
 # --- No content in logs, ever (the E3 acceptance property) ---------------------
 
 
@@ -147,6 +216,7 @@ def assert_no_content_logged(caplog, resp_content: str = "Hello."):
         assert SENTINEL not in rendered, (
             f"request content leaked into log record from {record.name}:{record.lineno}"
         )
+        # Also catch truncated leaks that drop the head of the sentinel.
         assert "John Doe" not in rendered
         assert resp_content not in rendered, (
             f"response content leaked into log record from {record.name}:{record.lineno}"
@@ -187,18 +257,20 @@ def test_no_content_in_logs_on_error_path(client, caplog, monkeypatch):
 
 
 # --- Drift guards ---------------------------------------------------------------
+#
+# Backstops only: the behavioral tests above are the acceptance property.
 
 DIAG_MARKER = "TPAI-" + "DIAG"  # split so this file never matches itself
+
+
+def source_files(root: Path):
+    return (p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
 
 
 def test_no_diag_markers_in_source():
     """The DIAG-line deletion is permanent — nothing may reintroduce the marker."""
     src_root = Path(__file__).resolve().parents[1]
-    offenders = [
-        str(path)
-        for path in src_root.rglob("*.py")
-        if "__pycache__" not in path.parts and DIAG_MARKER in path.read_text()
-    ]
+    offenders = [str(p) for p in source_files(src_root) if DIAG_MARKER in p.read_text()]
     assert offenders == []
 
 
@@ -208,9 +280,7 @@ def test_no_body_dump_logging_in_source():
     logger.info under DEBUG."""
     src_root = Path(__file__).resolve().parents[1] / "api"
     offenders = []
-    for path in src_root.rglob("*.py"):
-        if "__pycache__" in path.parts:
-            continue
+    for path in source_files(src_root):
         for lineno, line in enumerate(path.read_text().splitlines(), 1):
             if "logger." in line and (
                 "model_dump_json" in line

--- a/src/tests/test_audit.py
+++ b/src/tests/test_audit.py
@@ -66,6 +66,9 @@ def test_synthetic_record_matches_ratified_schema(fake_s3):
     assert call["Bucket"] == "tpai-audit-test-000000000000"
     assert call["Key"] == key
     assert call["ContentType"] == "application/json"
+    # Object Lock buckets require a checksum header; it must be explicit,
+    # not inherited from a botocore-version default.
+    assert call["ChecksumAlgorithm"] == "CRC32"
 
     record = json.loads(call["Body"])
     ts = record.pop("ts")

--- a/src/tests/test_audit.py
+++ b/src/tests/test_audit.py
@@ -1,0 +1,205 @@
+"""WORM audit-record emitter tests (external-content m1 Phase B(ii), R10/R11).
+
+Three properties:
+
+1. **Schema** — a synthetic record serializes to exactly the ratified R11
+   field set (schema-versioned, date-partitioned key, deterministic JSON).
+2. **Fail closed** — any failure to durably write (S3 error, missing
+   bucket config) raises ``AuditEmitError``; schema violations raise
+   ``ValueError``. There is no drop path.
+3. **No leakage** — the record (in particular the full URL target) never
+   appears in a log line, success or failure: CloudWatch stays
+   metadata-only (E3); full URLs belong only in the WORM trail.
+"""
+
+import json
+import logging
+
+import pytest
+
+import api.audit as audit
+from tests.conftest import expected_hmac
+
+IDENTITY = expected_hmac("owui-email", "alice@example.com")
+TARGET = "https://example.com/reports/q3?token=SENTINEL-URL-SECRET"
+
+SYNTHETIC = dict(
+    identity=IDENTITY,
+    tool="web_fetch",
+    target=TARGET,
+    policy_decision="allow",
+    policy_reason="beta-allow-all",
+    outcome="success",
+    bytes_returned=20480,
+    latency_ms=812,
+    conversation_id="chat-1234",
+)
+
+
+class FakeS3:
+    def __init__(self, fail_with: Exception | None = None):
+        self.calls = []
+        self.fail_with = fail_with
+
+    def put_object(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.fail_with is not None:
+            raise self.fail_with
+
+
+@pytest.fixture
+def fake_s3(monkeypatch):
+    fake = FakeS3()
+    monkeypatch.setattr(audit, "_s3", lambda: fake)
+    monkeypatch.setattr(audit, "AUDIT_BUCKET", "tpai-audit-test-000000000000")
+    return fake
+
+
+# --- Schema (the R11 contract) --------------------------------------------------
+
+
+def test_synthetic_record_matches_ratified_schema(fake_s3):
+    key = audit.emit_audit_record(**SYNTHETIC)
+
+    assert len(fake_s3.calls) == 1
+    call = fake_s3.calls[0]
+    assert call["Bucket"] == "tpai-audit-test-000000000000"
+    assert call["Key"] == key
+    assert call["ContentType"] == "application/json"
+
+    record = json.loads(call["Body"])
+    ts = record.pop("ts")
+    assert record == {
+        "schema": "tpai.gateway.tool-call.v1",
+        "identity": IDENTITY,
+        "tool": "web_fetch",
+        "target": TARGET,
+        "policy_decision": "allow",
+        "policy_reason": "beta-allow-all",
+        "outcome": "success",
+        "bytes": 20480,
+        "latency_ms": 812,
+        "conversation_id": "chat-1234",
+    }
+    # ISO-8601 UTC with millisecond precision, e.g. 2026-07-02T15:04:05.123+00:00
+    assert ts.startswith("20") and "T" in ts and "+00:00" in ts
+
+
+def test_key_is_date_partitioned_under_prefix(fake_s3):
+    key = audit.emit_audit_record(**SYNTHETIC)
+    prefix, y, m, d, leaf = key.split("/")
+    assert prefix == "gateway"
+    assert len(y) == 4 and len(m) == 2 and len(d) == 2
+    assert leaf.endswith(".json")
+
+
+def test_concurrent_writers_never_collide_on_key(fake_s3):
+    keys = {audit.emit_audit_record(**SYNTHETIC) for _ in range(50)}
+    assert len(keys) == 50
+
+
+def test_json_is_deterministic_and_compact(fake_s3):
+    audit.emit_audit_record(**SYNTHETIC)
+    body = fake_s3.calls[0]["Body"].decode()
+    assert body == json.dumps(json.loads(body), sort_keys=True, separators=(",", ":"))
+
+
+def test_optional_fields_serialize_as_null(fake_s3):
+    """bytes and conversation_id are nullable (denied calls return no bytes;
+    api-proxy callers have no chat id) — the fields still exist."""
+    audit.emit_audit_record(
+        **{
+            **SYNTHETIC,
+            "bytes_returned": None,
+            "conversation_id": None,
+            "outcome": "denied",
+            "policy_decision": "deny",
+            "policy_reason": "budget-exhausted",
+        }
+    )
+    record = json.loads(fake_s3.calls[0]["Body"])
+    assert record["bytes"] is None
+    assert record["conversation_id"] is None
+    assert record["policy_decision"] == "deny"
+
+
+# --- Fail closed ----------------------------------------------------------------
+
+
+def test_missing_identity_is_a_schema_violation(fake_s3):
+    with pytest.raises(ValueError, match="identity"):
+        audit.emit_audit_record(**{**SYNTHETIC, "identity": ""})
+    assert fake_s3.calls == []
+
+
+@pytest.mark.parametrize("field", ["tool", "target"])
+def test_missing_tool_or_target_is_a_schema_violation(fake_s3, field):
+    with pytest.raises(ValueError):
+        audit.emit_audit_record(**{**SYNTHETIC, field: ""})
+    assert fake_s3.calls == []
+
+
+def test_invalid_enums_rejected(fake_s3):
+    with pytest.raises(ValueError, match="policy_decision"):
+        audit.emit_audit_record(**{**SYNTHETIC, "policy_decision": "maybe"})
+    with pytest.raises(ValueError, match="outcome"):
+        audit.emit_audit_record(**{**SYNTHETIC, "outcome": "partial"})
+    assert fake_s3.calls == []
+
+
+def test_unconfigured_bucket_refuses(monkeypatch):
+    monkeypatch.setattr(audit, "AUDIT_BUCKET", "")
+    with pytest.raises(audit.AuditEmitError, match="TPAI_AUDIT_BUCKET"):
+        audit.emit_audit_record(**SYNTHETIC)
+
+
+def test_s3_failure_raises_audit_emit_error(monkeypatch):
+    fake = FakeS3(fail_with=ConnectionError("endpoint unreachable"))
+    monkeypatch.setattr(audit, "_s3", lambda: fake)
+    monkeypatch.setattr(audit, "AUDIT_BUCKET", "tpai-audit-test-000000000000")
+    with pytest.raises(audit.AuditEmitError) as excinfo:
+        audit.emit_audit_record(**SYNTHETIC)
+    assert isinstance(excinfo.value.__cause__, ConnectionError)
+
+
+# --- No leakage into logs (E3 stays intact) -------------------------------------
+
+
+def assert_no_record_fields_logged(caplog):
+    for r in caplog.records:
+        rendered = r.getMessage()
+        assert TARGET not in rendered, f"full URL leaked into log from {r.name}"
+        assert "SENTINEL-URL-SECRET" not in rendered
+        assert IDENTITY not in rendered
+        assert "chat-1234" not in rendered
+
+
+def test_success_logs_nothing(fake_s3, caplog):
+    caplog.set_level(logging.DEBUG)
+    audit.emit_audit_record(**SYNTHETIC)
+    assert_no_record_fields_logged(caplog)
+
+
+def test_failure_log_carries_no_record_fields(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG)
+    fake = FakeS3(fail_with=ConnectionError("endpoint unreachable"))
+    monkeypatch.setattr(audit, "_s3", lambda: fake)
+    monkeypatch.setattr(audit, "AUDIT_BUCKET", "tpai-audit-test-000000000000")
+    with pytest.raises(audit.AuditEmitError):
+        audit.emit_audit_record(**SYNTHETIC)
+    # The failure line exists (operators must see audit-write failures)…
+    assert any("audit record write failed" in r.getMessage() for r in caplog.records)
+    # …but never the record: URL/identity live only in the WORM trail.
+    assert_no_record_fields_logged(caplog)
+
+
+def test_exception_chain_carries_no_record_fields(monkeypatch):
+    """AuditEmitError propagates to the tool loop, whose error handling may
+    log it — the exception text itself must stay record-free."""
+    fake = FakeS3(fail_with=ConnectionError("endpoint unreachable"))
+    monkeypatch.setattr(audit, "_s3", lambda: fake)
+    monkeypatch.setattr(audit, "AUDIT_BUCKET", "tpai-audit-test-000000000000")
+    with pytest.raises(audit.AuditEmitError) as excinfo:
+        audit.emit_audit_record(**SYNTHETIC)
+    assert TARGET not in str(excinfo.value)
+    assert IDENTITY not in str(excinfo.value)

--- a/src/tests/test_identity.py
+++ b/src/tests/test_identity.py
@@ -1,0 +1,191 @@
+"""Identity middleware tests (external-content m1 Phase A / decisions D7, E2).
+
+Covers: HMAC derivation + domain separation, reject-missing on
+identity-required routes, api-proxy identity mapping, conflicting-header
+rejection, enforcement-disabled (pre-flip / rollback) behavior, and the
+raw-email-never-logged log-capture assertion.
+"""
+
+import hashlib
+import hmac
+import logging
+
+import api.identity as identity
+from tests.conftest import AUTH, CHAT_BODY
+
+TEST_KEY = "test-identity-hmac-key"
+TEST_EMAIL = "Alice.Example@Example.COM"
+
+
+def expected_hmac(domain: str, value: str) -> str:
+    return hmac.new(TEST_KEY.encode(), f"{domain}:{value}".encode(), hashlib.sha256).hexdigest()
+
+
+# --- Enforcement on identity-required routes ---------------------------------
+
+
+def test_chat_missing_identity_rejected(client):
+    resp = client.post("/api/v1/chat/completions", json=CHAT_BODY, headers=AUTH)
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Missing user identity"
+
+
+def test_embeddings_missing_identity_rejected(client):
+    resp = client.post(
+        "/api/v1/embeddings",
+        json={"model": "cohere.embed-multilingual-v3", "input": ["hi"]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 401
+
+
+def test_chat_with_owui_email_accepted(client):
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json=CHAT_BODY,
+        headers={**AUTH, identity.OWUI_EMAIL_HEADER: TEST_EMAIL},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"]["content"] == "Hello."
+
+
+def test_chat_with_api_proxy_identity_accepted(client):
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json=CHAT_BODY,
+        headers={**AUTH, identity.API_PROXY_USER_HEADER: "a" * 64},
+    )
+    assert resp.status_code == 200
+
+
+def test_conflicting_identity_headers_rejected(client):
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json=CHAT_BODY,
+        headers={
+            **AUTH,
+            identity.OWUI_EMAIL_HEADER: TEST_EMAIL,
+            identity.API_PROXY_USER_HEADER: "a" * 64,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_empty_identity_header_treated_as_missing(client):
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json=CHAT_BODY,
+        headers={**AUTH, identity.OWUI_EMAIL_HEADER: "   "},
+    )
+    assert resp.status_code == 401
+
+
+def test_identity_still_requires_api_key(client):
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json=CHAT_BODY,
+        headers={
+            "Authorization": "Bearer wrong-key",
+            identity.OWUI_EMAIL_HEADER: TEST_EMAIL,
+        },
+    )
+    assert resp.status_code == 401
+
+
+# --- Routes that must NOT require identity -----------------------------------
+
+
+def test_health_requires_nothing(client):
+    assert client.get("/health").status_code == 200
+
+
+def test_models_requires_key_but_not_identity(client, monkeypatch):
+    monkeypatch.setattr(
+        "api.routers.model.chat_model.list_models",
+        lambda: ["anthropic.claude-3-sonnet-20240229-v1:0"],
+    )
+    resp = client.get("/api/v1/models", headers=AUTH)
+    assert resp.status_code == 200
+
+
+# --- HMAC derivation ----------------------------------------------------------
+
+
+def _resolve(headers: dict[str, str]) -> tuple[str, "Request"]:
+    """Run the dependency directly against a synthetic request."""
+    import asyncio
+
+    from starlette.requests import Request
+
+    scope = {
+        "type": "http",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+    }
+    request = Request(scope)
+    result = asyncio.run(identity.require_identity(request))
+    return result, request
+
+
+def test_email_identity_is_domain_separated_hmac():
+    """The resolved identity is HMAC-SHA256('owui-email:' + lowercased email)."""
+    result, request = _resolve({identity.OWUI_EMAIL_HEADER: TEST_EMAIL})
+    assert result == expected_hmac("owui-email", TEST_EMAIL.lower())
+    assert request.state.tpai_identity == result
+
+
+def test_api_proxy_identity_uses_distinct_domain():
+    value = "ABCDEF" + "0" * 58
+    result, _ = _resolve({identity.API_PROXY_USER_HEADER: value})
+    assert result == expected_hmac("api-key-user", value.lower())
+    # Domain separation: same input string under the email domain differs.
+    assert result != expected_hmac("owui-email", value.lower())
+
+
+# --- Enforcement disabled (pre-flip / rolled-back deployment) ------------------
+
+
+def test_no_key_disables_enforcement(client, monkeypatch):
+    monkeypatch.setattr(identity, "IDENTITY_HMAC_KEY", "")
+    resp = client.post("/api/v1/chat/completions", json=CHAT_BODY, headers=AUTH)
+    assert resp.status_code == 200
+
+
+# --- The raw email never appears in logs (plan.md Phase A verification) --------
+
+
+def test_raw_email_never_logged(client, caplog):
+    """Log-capture proof: a request carrying a raw email produces no log line
+    containing it — the email's only line of existence is the HMAC call."""
+    caplog.set_level(logging.DEBUG)
+    resp = client.post(
+        "/api/v1/chat/completions",
+        json=CHAT_BODY,
+        headers={**AUTH, identity.OWUI_EMAIL_HEADER: TEST_EMAIL},
+    )
+    assert resp.status_code == 200
+
+    email_variants = {TEST_EMAIL, TEST_EMAIL.lower(), TEST_EMAIL.upper()}
+    for record in caplog.records:
+        rendered = record.getMessage()
+        for variant in email_variants:
+            assert variant not in rendered, (
+                f"raw email leaked into log record from {record.name}:{record.lineno}"
+            )
+    # And it never leaks into the response body either.
+    for variant in email_variants:
+        assert variant not in resp.text
+
+
+def test_raw_email_never_logged_on_rejection_paths(client, caplog):
+    caplog.set_level(logging.DEBUG)
+    client.post(
+        "/api/v1/chat/completions",
+        json=CHAT_BODY,
+        headers={
+            **AUTH,
+            identity.OWUI_EMAIL_HEADER: TEST_EMAIL,
+            identity.API_PROXY_USER_HEADER: "a" * 64,
+        },
+    )
+    assert TEST_EMAIL not in caplog.text
+    assert TEST_EMAIL.lower() not in caplog.text

--- a/src/tests/test_identity.py
+++ b/src/tests/test_identity.py
@@ -6,19 +6,12 @@ rejection, enforcement-disabled (pre-flip / rollback) behavior, and the
 raw-email-never-logged log-capture assertion.
 """
 
-import hashlib
-import hmac
 import logging
 
 import api.identity as identity
-from tests.conftest import AUTH, CHAT_BODY
+from tests.conftest import AUTH, CHAT_BODY, expected_hmac
 
-TEST_KEY = "test-identity-hmac-key"
 TEST_EMAIL = "Alice.Example@Example.COM"
-
-
-def expected_hmac(domain: str, value: str) -> str:
-    return hmac.new(TEST_KEY.encode(), f"{domain}:{value}".encode(), hashlib.sha256).hexdigest()
 
 
 # --- Enforcement on identity-required routes ---------------------------------

--- a/src/tests/test_identity.py
+++ b/src/tests/test_identity.py
@@ -150,6 +150,28 @@ def test_no_key_disables_enforcement(client, monkeypatch):
     assert resp.status_code == 200
 
 
+def test_disabled_enforcement_still_sets_request_state(monkeypatch):
+    """Downstream audit/budget consumers read request.state.tpai_identity
+    unconditionally — it must exist (as None) in the disabled state too."""
+    monkeypatch.setattr(identity, "IDENTITY_HMAC_KEY", "")
+    result, request = _resolve({identity.OWUI_EMAIL_HEADER: TEST_EMAIL})
+    assert result is None
+    assert request.state.tpai_identity is None
+
+
+def test_enforce_flag_without_key_refuses_startup():
+    """Fail closed (TPAI_IDENTITY_ENFORCE): a deployment that declares
+    enforcement but lost the HMAC key must crash, not boot fail-open."""
+    import pytest
+
+    with pytest.raises(RuntimeError, match="TPAI_IDENTITY_ENFORCE"):
+        identity._require_key_when_enforced(True, "")
+    # All other combinations start normally.
+    identity._require_key_when_enforced(True, "some-key")
+    identity._require_key_when_enforced(False, "")
+    identity._require_key_when_enforced(False, "some-key")
+
+
 # --- The raw email never appears in logs (plan.md Phase A verification) --------
 
 


### PR DESCRIPTION
## What

The gateway side of the external-content program's **WORM audit sink** (m1 Phase B(ii); plan: `plans/external-content/m1-substrate/plan.md` §Phase B in the main repo — decisions **R10** 7-year WORM retention, **R11** record schema).

- `src/api/audit.py` — `emit_audit_record()`: one schema-versioned JSON record per server-side tool call, written to the S3 Object Lock bucket stood up by the main repo's `audit-sink-stack` (companion PR bumps the submodule + wires `TPAI_AUDIT_BUCKET` and task-role IAM).
- Schema `tpai.gateway.tool-call.v1` per ratified R11: HMAC identity, tool, **full URL or message-id** target, policy decision + reason, outcome, **bytes**, **latency**, conversation id. Documented in `docs/AuditRecords.md`.
- **Fail closed**: any write failure — including an unconfigured bucket — raises `AuditEmitError`; a retrieval that cannot be audited must not happen (ADR-1: *every retrieval is logged*). No fire-and-forget, no buffer-and-drop.
- **Records never touch logs** (E3 stays metadata-only): full URLs/identities exist only in the WORM trail; failure logs carry exception class + S3 key only.
- **Dark**: no production call sites until the m2 `web_fetch` tool lands; docs pin the m2 wiring requirement (single audited choke point covering success/denied/error/timeout).

## Review-pass hardening (commit 6652311)

- `gateway/` prefix is a constant, not an env var (IAM pins `gateway/*`; any other value = AccessDenied outage behind fail-closed).
- Bounded fail-closed latency: 2 attempts × (3s connect + 5s read) ≈ 17s ceiling (was ~50s with defaults).
- Explicit `ChecksumAlgorithm=CRC32` (Object Lock requires a checksum header; not left to the botocore ≥1.36 default).
- conftest pops `TPAI_AUDIT_BUCKET` so no test can ever PUT to a real bucket.

## Verification

- `python -m pytest` in pinned venv (CI parity): **43 passed** (29 existing + 14 new audit tests: exact-schema synthetic record, date-partitioned collision-free keys, deterministic JSON, fail-closed on S3 error/unconfigured bucket, ValueError on schema violations, and log-capture tests asserting no record field ever reaches a log line or exception text).
- `ruff check`: clean; new files `ruff format`ed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)