### PR TITLE
fix: handle empty tool_call arguments instead of raising JSONDecodeError

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -573,7 +573,19 @@ class BedrockModel(BaseChatModel):
                 if message.tool_calls:
                     # Tool use message
                     for tool_call in message.tool_calls:
-                        tool_input = json.loads(tool_call.function.arguments)
+                        # OpenAI clients send arguments="" for tool calls that take no
+                        # arguments, so json.loads() would raise. Treat empty or
+                        # unparsable arguments as an empty input object rather than
+                        # failing the whole request.
+                        raw_arguments = tool_call.function.arguments or ""
+                        try:
+                            tool_input = json.loads(raw_arguments) if raw_arguments.strip() else {}
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "Unparsable arguments for tool call %s, using empty input",
+                                tool_call.id,
+                            )
+                            tool_input = {}
                         messages.append(
                             {
                                 "role": message.role,


### PR DESCRIPTION
*Issue #, if available:* none filed — happy to open one if you'd prefer to track it separately.

*Description of changes:*

## Problem

OpenAI clients send `arguments: ""` for a tool call that takes no arguments. `_parse_messages` passes that value straight to `json.loads()`, which raises:

```
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Because this happens while deserializing the **request**, it fires before any Bedrock call is made — the Lambda fails in ~4ms and the client sees an error frame:

```json
data: {"error":{"message":"Expecting value: line 1 column 1 (char 0)"}}
```

For an agentic client this is unrecoverable rather than merely annoying: once a no-argument tool call is in the conversation history, **every** subsequent turn replays that history and fails identically, so the session cannot progress and retries just repeat the failure.

I hit this running GitHub Copilot CLI in BYOK mode against the gateway on Claude Opus. Single-shot prompts worked fine, which is what made it puzzling at first — the first turn has no history to re-parse, so the bug only appears on the turn *after* a no-argument tool call.

## Reproduction

Against a deployed gateway (any Claude model with tool support):

```json
{
  "model": "au.anthropic.claude-opus-5",
  "stream": true,
  "messages": [
    {"role": "user", "content": "what time is it"},
    {"role": "assistant", "tool_calls": [
      {"id": "call_1", "type": "function",
       "function": {"name": "get_time", "arguments": ""}}]},
    {"role": "tool", "tool_call_id": "call_1", "content": "10:00"}
  ],
  "tools": [{"type": "function", "function": {
    "name": "get_time", "description": "time",
    "parameters": {"type": "object", "properties": {}}}}]
}
```

Changing `"arguments": ""` to `"arguments": "{}"` makes the same request succeed, which isolates the cause to the parse rather than anything model- or Bedrock-side.

## Change

`arguments` that is empty, whitespace-only, or `None` now yields an empty input object `{}` — which is the correct Bedrock `toolUse.input` for a tool invoked with no arguments.

Arguments that are non-empty but unparsable are also treated as `{}` rather than failing the entire request, with a warning logged so a genuine client-side problem is still visible. I went with the lenient branch because a hard failure here kills the whole conversation, whereas an empty input lets the model observe the tool result and recover; happy to switch it to a 400 if you'd rather surface malformed client output loudly.

Scoped to the one parse site so the diff stays reviewable (+13/-1). No behaviour change for well-formed arguments.

## Verification

Verified against a live API Gateway + Lambda deployment (Claude Opus, `ap-southeast-2`):

- the payload above returns an error frame before the change, and streams normally after it
- a multi-turn agentic Copilot CLI session — multiple tool calls, file reads, two file edits, a shell verification step, ~198k prompt tokens — completes cleanly, where it previously failed on the second turn
- CloudWatch confirms the Bedrock invocations, and the Lambda log shows 21+ consecutive requests with `200` and zero occurrences of the crash signature after deploying the change

Table-checked the parse branch across: `""`, `"   "`, `None`, `"{}"`, valid JSON, nested JSON, and malformed input.

## Note on the related index bug

While debugging this I also reproduced the streamed `tool_calls[].index = -1` issue (a turn that *opens* with a tool call). That one is already addressed by open PR #247, so I've deliberately left it out of this PR to avoid duplicating that work — this change is only the `arguments` parse fix. I've commented on #247 confirming I hit it independently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
